### PR TITLE
[add]ボタンコンポーネントの作成(#6)

### DIFF
--- a/view/next-project/public/arrow_right_black_24dp.svg
+++ b/view/next-project/public/arrow_right_black_24dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M10 17l5-5-5-5v10z"/><path d="M0 24V0h24v24H0z" fill="none"/></svg>

--- a/view/next-project/src/assets/base.css
+++ b/view/next-project/src/assets/base.css
@@ -9,6 +9,9 @@
   --text-primary: #333333;
   --text-secondary: white;
 
+  --button-primary: #34dde8;
+  --button-secondary: #3492e8;
+
   --hover: rgba(0, 0, 0, 0.075);
   --hover-1: rgba(0, 0, 0, 0.15);
   --hover-2: rgba(0, 0, 0, 0.25);
@@ -38,12 +41,13 @@
   --accent-9: #000;
 
   --card-radius: 25px;
+  --button-radius: 50px;
 
-  --font-sans: -apple-system, system-ui, BlinkMacSystemFont, 'Helvetica Neue',
-    'Helvetica', sans-serif;
+  --font-sans: -apple-system, system-ui, BlinkMacSystemFont, "Helvetica Neue",
+    "Helvetica", sans-serif;
 }
 
-[data-theme='dark'] {
+[data-theme="dark"] {
   --primary: #000000;
   --primary-2: #111;
   --secondary: #ffffff;

--- a/view/next-project/src/assets/base.css
+++ b/view/next-project/src/assets/base.css
@@ -1,7 +1,7 @@
 :root {
   --primary: #ffac5d;
   --primary-2: #f1f3f5;
-  --secondary: #000000;
+  --secondary: #ffffff;
   --secondary-2: #111;
   --selection: var(--cyan);
 

--- a/view/next-project/src/components/common/Button.tsx
+++ b/view/next-project/src/components/common/Button.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import styled from "styled-components";
+import RightArrow from "@components/icons/RightArrow";
+
+type ButtonContentsProps = {
+  width?: string;
+  height?: string;
+  text?: string;
+  children: React.ReactNode;
+};
+
+function Button(props: ButtonContentsProps): JSX.Element {
+  const ButtonContainer = styled.div`
+    background: radial-gradient(
+      ellipse at top left,
+      var(--button-primary),
+      var(--button-secondary)
+    );
+    width: ${props.width};
+    height: ${props.height};
+    border-radius: var(--button-radius);
+    box-shadow: 0 2px 2px rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(4px);
+    text-align: center;
+    font-size: 14px;
+    color: var(--accent-0);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  `;
+
+  return (
+    <>
+      <ButtonContainer>
+        {props.children}
+        {props.text}
+        <RightArrow height="16" width="16" color="--secondary" />
+      </ButtonContainer>
+    </>
+  );
+}
+
+export default Button;

--- a/view/next-project/src/components/common/TransButton.tsx
+++ b/view/next-project/src/components/common/TransButton.tsx
@@ -10,7 +10,7 @@ type ButtonContentsProps = {
 };
 
 function Button(props: ButtonContentsProps): JSX.Element {
-  const ButtonContainer = styled.div`
+  const ButtonContainer = styled.button`
     background: radial-gradient(
       ellipse at top left,
       var(--button-primary),

--- a/view/next-project/src/components/icons/RightArrow.tsx
+++ b/view/next-project/src/components/icons/RightArrow.tsx
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+
+type Props = {
+  width?: number;
+  height?: number;
+  color?: string;
+};
+
+const RightArrow = (props: Props) => {
+  const svg = styled.svg`
+    position: relative;
+    right: 0;
+  `;
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={props.width}
+      viewBox="0 0 24 24"
+      height={props.height}
+      fill={props.color}
+    >
+      <path d="M10 17l5-5-5-5v10z" />
+      <path d="M0 24V0h24v24H0z" fill="none" />
+    </svg>
+  );
+};
+
+export default RightArrow;


### PR DESCRIPTION
ボタンコンポーネント作成しました。
`<Button width={"149px"} height={"32px"} text={"More"}></Button>` のように呼び出せます。

右矢印アイコンは、あまり良いのがなく一旦画像のものにしました。
また、ポジションも調節方法がわからなかったため、とりあえず配置のみ行っています。
ボタンコンポーネントを作成することを優先したほうがいいと思ったので、一旦プルリクの確認お願いします

![image](https://user-images.githubusercontent.com/71711872/146769241-bf445be1-aa39-4a6e-8da7-02bc45d982bb.png)
