### PR TITLE
[add]カリキュラムの追加機能を実装(#29)

### DIFF
--- a/view/next-project/src/components/common/AddButton.tsx
+++ b/view/next-project/src/components/common/AddButton.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+import Add from '@components/icons/Add';
+
+interface ButtonContentsProps {
+  width?: string;
+  height?: string;
+  text?: string;
+  onClick: (event: any) => void;
+  children?: React.ReactNode;
+};
+
+function TestButton(props: ButtonContentsProps): JSX.Element {
+  const ButtonContainer = styled.button`
+    background: radial-gradient(var(--button-primary), var(--button-secondary));
+    width: ${props.width || '40px'};
+    height: ${props.height || '40px'};
+    border-radius: 50%;
+    box-shadow: 0 2px 2px rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(4px);
+    text-align: center;
+    font-size: 14px;
+    color: var(--accent-0);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: none;
+    &:active {
+      box-shadow: 0 0px 0px rgba(0, 0, 0, 0.25);
+    }
+  `;
+
+  return (
+    <>
+      <ButtonContainer onClick={props.onClick}>
+        {props.children}
+        {props.text}
+        <Add height={24} width={24} color='var(--accent-0)' />
+      </ButtonContainer>
+    </>
+  );
+}
+
+export default TestButton;

--- a/view/next-project/src/components/common/AddModal/AddModal.module.css
+++ b/view/next-project/src/components/common/AddModal/AddModal.module.css
@@ -73,6 +73,22 @@
   outline: 0;
 }
 
+.modalContent select {
+  font-size: 1.6rem;
+  width: 48rem;
+  letter-spacing: 1px;
+  color: var(--accent-6);
+  background: none;
+  border: 1px solid var(--accent-4);
+  padding: 10px;
+}
+
+.modalContent select:focus {
+  border: 1px solid var(--button-secondary);
+  z-index: 10;
+  outline: 0;
+}
+
 .modalContentClose {
   background: none;
   border: none;
@@ -88,3 +104,4 @@
 
 .textButton:active {
 }
+

--- a/view/next-project/src/components/common/CurriculumAddModal.tsx
+++ b/view/next-project/src/components/common/CurriculumAddModal.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import AddModal from '@components/common/AddModal';
+import Button from '@components/common/TestButton';
+import { post } from '@utils/api_methods';
+
+interface Skills {
+  id: number;
+  name: string;
+  detail: string;
+  category_id: number;
+};
+
+interface ModalProps {
+  isOpen: boolean;
+  setIsOpen: any;
+  children?: React.ReactNode;
+  skills: Skills[];
+}
+
+interface Curriculums {
+  title: string;
+  content: string;
+  homework: string;
+  skill_id: number;
+}
+
+const submitProject = async (data: Curriculums) => {
+  console.log("******");
+  console.log(data);
+  console.log("******");
+  const postUrl = 'http://localhost:3000/curriculums';
+  const postReq = await post(postUrl, data);
+};
+
+const ProjectAddModal = (props: ModalProps) => {
+  const router = useRouter();
+  const [formData, setFormData] = useState({
+    title: '',
+    content: '',
+    homework: '',
+    skill_id: 1,
+  });
+  const handler =
+    (input: string) => (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement> | React.ChangeEvent<HTMLSelectElement>) => {
+      setFormData({ ...formData, [input]: e.target.value });
+    };
+
+  return (
+    <AddModal show={props.isOpen} setShow={props.setIsOpen}>
+      <h2>New Curriculum</h2>
+      <div>
+        <h3>Curriculum Title</h3>
+        <input type='text' placeholder='Input' value={formData.title} onChange={handler('title')} />
+      </div>
+      <div>
+        <h3>Content</h3>
+        <textarea placeholder='Input' value={formData.content} onChange={handler('content')} />
+      </div>
+      <div>
+        <h3>Homework</h3>
+        <textarea placeholder='Input' value={formData.homework} onChange={handler('homework')} />
+      </div>
+      <div>
+        <h3>Skill</h3>
+        <select defaultValue={formData.skill_id} onChange={handler('skill_id')}>
+          {props.skills.map(data => <option value={data.id}>{data.name}</option>)}
+        </select>
+      </div>
+      <Button onClick={() => {
+        submitProject(formData);
+        router.reload();
+      }}>Submit</Button>
+    </AddModal>
+  );
+};
+
+export default ProjectAddModal;

--- a/view/next-project/src/components/common/ListHeader/ListHeader.module.css
+++ b/view/next-project/src/components/common/ListHeader/ListHeader.module.css
@@ -1,0 +1,20 @@
+.HeaderContainer {
+  display: flex;
+  width: 100%;
+}
+ 
+.SplitLeftContainer {
+  padding-left: 10px;
+  flex-grow: 1;
+  display: flex;
+  justify-content: start;
+  align-items: center;
+}
+ 
+.SplitRightContainer {
+  flex-grow: 1;
+  display: flex;
+  justify-content: end;
+  align-items: center;
+}
+ 

--- a/view/next-project/src/components/common/ListHeader/ListHeader.tsx
+++ b/view/next-project/src/components/common/ListHeader/ListHeader.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import ListPageTitle from '@components/common/ListPageTitle';
+import Button from '@components/common/AddButton';
+import s from './ListHeader.module.css';
+import CurriculumAddModal from '@components/common/CurriculumAddModal';
+
+interface Skills {
+  id: number;
+  name: string;
+  detail: string;
+  category_id: number;
+};
+
+interface Props {
+  title: string;
+  children?: React.ReactNode;
+  skills: Skills[];
+}
+
+const ListHeader = (props: Props) => {
+  const [isOpenAddModal, setIsOpenAddModal] = useState(false);
+  const AddModal = (isOpenAddModal: boolean) => {
+    if (isOpenAddModal) {
+      return (
+        <>
+          <CurriculumAddModal isOpen={isOpenAddModal} setIsOpen={setIsOpenAddModal} skills={props.skills} />
+        </>
+      );
+    }
+  };
+  return (
+    <div className={s.HeaderContainer}>
+      <div className={s.SplitLeftContainer}>
+        <ListPageTitle title={props.title} />
+      </div>
+      <div className={s.SplitRightContainer}>
+        <Button onClick={() => setIsOpenAddModal(!isOpenAddModal)}></Button>
+        {AddModal(isOpenAddModal)}
+      </div>
+    </div>
+  );
+};
+
+export default ListHeader;

--- a/view/next-project/src/components/common/ListHeader/index.ts
+++ b/view/next-project/src/components/common/ListHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ListHeader';

--- a/view/next-project/src/components/common/ListPageTitle/ListPageTitle.module.css
+++ b/view/next-project/src/components/common/ListPageTitle/ListPageTitle.module.css
@@ -1,0 +1,8 @@
+.modalContainer {
+  font-size: 2.4rem;
+  font-weight: bold;
+  color: var(--text-secondary);
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+}

--- a/view/next-project/src/components/common/ListPageTitle/ListPageTitle.tsx
+++ b/view/next-project/src/components/common/ListPageTitle/ListPageTitle.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import s from './ListPageTitle.module.css';
+
+interface Props {
+  title: string;
+}
+
+const ListPageTitle = (props: Props) => {
+  return (
+    <div className={s.modalContainer}>
+      {props.title}
+    </div>
+  );
+};
+
+export default ListPageTitle;

--- a/view/next-project/src/components/common/ListPageTitle/index.ts
+++ b/view/next-project/src/components/common/ListPageTitle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ListPageTitle';

--- a/view/next-project/src/components/icons/Add.tsx
+++ b/view/next-project/src/components/icons/Add.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+interface Props {
+  width?: number;
+  height?: number;
+  color?: string;
+};
+
+const Add = (props: Props) => {
+  const svg = styled.svg`
+    position: relative;
+    right: 0;
+  `;
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width={props.width}
+      viewBox='0 0 24 24'
+      height={props.height}
+      fill={props.color}
+    >
+      <path d="M0 0h24v24H0V0z" fill="none" />
+      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+    </svg>
+  );
+};
+
+export default Add;

--- a/view/next-project/src/pages/curriculumlist.tsx
+++ b/view/next-project/src/pages/curriculumlist.tsx
@@ -2,10 +2,11 @@ import { useState } from 'react';
 import Router from 'next/router';
 import { get } from '@utils/api_methods';
 import MainLayout from '@components/layout/MainLayout';
+import ListHeader from '@components/common/ListHeader';
 import FlatCard from '@components/common/FlatCard';
 import Table from '@components/common/Table';
 
-type Curriculum = {
+interface Curriculum {
   id: number;
   title: string;
   content: string;
@@ -15,16 +16,27 @@ type Curriculum = {
   updated_at: string;
 };
 
+interface Skills {
+  id: number;
+  name: string;
+  detail: string;
+  category_id: number;
+};
+
 type Props = {
   curriculums: Curriculum[];
+  skills: Skills[];
 };
 
 export async function getStaticProps() {
-  const getUrl = 'http://seeds_api:3000/curriculums';
-  const json = await get(getUrl);
+  const getCurriculumsUrl = 'http://seeds_api:3000/curriculums';
+  const getSkillsUrl = 'http://seeds_api:3000/skills';
+  const curriculumsJson = await get(getCurriculumsUrl);
+  const skillsJson = await get(getSkillsUrl);
   return {
     props: {
-      curriculums: json,
+      curriculums: curriculumsJson,
+      skills: skillsJson,
     },
   };
 }
@@ -39,7 +51,8 @@ export default function CurriculumList(props: Props) {
   return (
     <>
       <MainLayout>
-        <FlatCard>
+        <ListHeader title="Curriculum" skills={props.skills} />
+        <FlatCard width="100%">
           <Table headers={headers}>
             {props.curriculums.map((curriculum) => (
               <tr key={curriculum.toString()} onClick={() => Router.push('/curriculums/' + curriculum.id)}>

--- a/view/next-project/src/utils/api_methods.ts
+++ b/view/next-project/src/utils/api_methods.ts
@@ -21,13 +21,14 @@ export const get_with_token = async (url: string) => {
   return await res.json();
 };
 
-export const post = async (url: string) => {
+export const post = async (url: string, data: any) => {
   const res = await fetch(url, {
     method: 'POST',
     mode: 'cors',
     headers: {
       'Content-Type': 'application/json',
     },
+    body: JSON.stringify(data),
   });
   return res;
 };


### PR DESCRIPTION
カリキュラムの追加機能を実装しました。  
pushしたファイルのtypeはinterfaceに変更しておきました。  

# テスト内容
- http://localhost:8080/curriculumlist にアクセスして一覧カード右上のプラスボタンからカリキュラム追加用のモーダルが開くか
- モーダルのSubmitボタンを押すと、画面がリロードされて入力された項目が追加されるか
- skillを選択していない場合は初期値でTypeScriptが入っているか
