### PR TITLE
[add]skillの個別ページの作成(#84)

### DIFF
--- a/api/app/controllers/api/v1/skills_api_controller.rb
+++ b/api/app/controllers/api/v1/skills_api_controller.rb
@@ -14,6 +14,10 @@ class Api::V1::SkillsApiController < ApplicationController
   def get_skill_for_reload_index
     @record = Skill.with_category(params[:id])
     render json: @record
-
+  end
+  
+  def get_skill_for_view
+    @record = Skill.with_category_and_detail(params[:id])
+    render json: @record
   end
 end

--- a/api/app/models/skill.rb
+++ b/api/app/models/skill.rb
@@ -32,5 +32,16 @@ class Skill < ApplicationRecord
         }
     }
   end
+  def self.with_category_and_detail(skill_id)
+    skill = Skill.find(skill_id)
+    {
+      "id": skill.id,
+      "name": skill.name,
+      "detail": skill.detail,
+      "category_id": skill.category.id,
+      "category_name": skill.category.name,
+      "created_at": skill.created_at,
+    }
+  end
 
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
       # For Skill
       get "/get_skills_for_index" => "skills_api#get_skills_for_index"
       get "/get_skill_for_reload_index/:id" => "skills_api#get_skill_for_reload_index"
+      get "/get_skill_for_view/:id" => "skills_api#get_skill_for_view"
 
     end
   end

--- a/view/next-project/src/components/common/SkillDeleteModal.tsx
+++ b/view/next-project/src/components/common/SkillDeleteModal.tsx
@@ -1,0 +1,57 @@
+import React, {FC, useEffect, useState} from 'react';
+import {useRouter} from 'next/router';
+import {del, get} from '@utils/api_methods';
+import DeleteModal from '@components/common/DeleteModal';
+import Button from '@components/common/TestButton';
+
+interface ModalProps {
+  isOpen: boolean;
+  setIsOpen: Function;
+}
+
+const RecordDeleteModal: FC<ModalProps> = (props) => {
+  const [formData, setFormData] = useState({
+    name: '',
+    detail: '',
+    category_id: '',
+  });
+  const router = useRouter();
+  const query = router.query;
+
+  useEffect(() => {
+    if (router.isReady) {
+      const getFormDataUrl = process.env.CSR_API_URI + '/skills/' + query.id;
+      const getFormData = async (url: string) => {
+        setFormData(await get(url));
+      };
+      getFormData(getFormDataUrl);
+    }
+  }, [query, router]);
+
+  const handler =
+    (input: string) => (e: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => {
+      setFormData({...formData, [input]: e.target.value});
+    };
+
+  const DeleteRecord = async (query: any) => {
+    const deleteRecordUrl = process.env.CSR_API_URI + '/skills/' + query.id;
+    await del(deleteRecordUrl);
+  };
+
+  return (
+    <DeleteModal show={props.isOpen} setShow={props.setIsOpen}>
+      <h2>Delete Record</h2>
+      <h3>Are you sure?</h3>
+      <Button
+        onClick={() => {
+          DeleteRecord(query);
+          router.back();
+        }}
+      >
+        Delete
+      </Button>
+    </DeleteModal>
+  );
+};
+
+export default RecordDeleteModal;

--- a/view/next-project/src/components/common/SkillDetailHeader/SkillDetailHeader.module.css
+++ b/view/next-project/src/components/common/SkillDetailHeader/SkillDetailHeader.module.css
@@ -13,35 +13,5 @@
   justify-content: center;
   align-items: center;
   flex-flow: row;
-}
-
-.TextContainer {
-  font-size: 1.6rem;
-  color: var(--text-secondary);
-  height: 100%;
-  width: 100%;
-  overflow: auto;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding-top: 10px;
-  flex-flow: row;
-}
-
-.SkillContainer {
-  font-size: 1.6rem;
-  color: var(--text-secondary);
-  height: 100%;
-  width: 100%;
-  overflow: auto;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding-top: 20px;
-  flex-flow: row;
-}
-
-.DescriptionContainer {
-  margin: 0 1.5rem;
   padding-bottom: 10px;
 }

--- a/view/next-project/src/components/common/SkillDetailHeader/SkillDetailHeader.module.css
+++ b/view/next-project/src/components/common/SkillDetailHeader/SkillDetailHeader.module.css
@@ -1,0 +1,47 @@
+.HeaderContainer {
+  width: 100%;
+}
+
+.TitleContainer {
+  font-size: 3.2rem;
+  font-weight: bold;
+  color: var(--text-secondary);
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-flow: row;
+}
+
+.TextContainer {
+  font-size: 1.6rem;
+  color: var(--text-secondary);
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 10px;
+  flex-flow: row;
+}
+
+.SkillContainer {
+  font-size: 1.6rem;
+  color: var(--text-secondary);
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 20px;
+  flex-flow: row;
+}
+
+.DescriptionContainer {
+  margin: 0 1.5rem;
+  padding-bottom: 10px;
+}

--- a/view/next-project/src/components/common/SkillDetailHeader/SkillDetailHeader.tsx
+++ b/view/next-project/src/components/common/SkillDetailHeader/SkillDetailHeader.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import s from './SkillDetailHeader.module.css';
+import Tag from '@components/common/Tag';
+
+interface Props {
+  children?: React.ReactNode;
+  skillName: string;
+  createDate: string;
+}
+
+const SkillDetailHeader = (props: Props) => {
+  return (
+    <div className={s.HeaderContainer}>
+      <div className={s.TitleContainer}>{props.skillName}</div>
+      <div className={s.TextContainer}>
+        <div className={s.DescriptionContainer}>Create Date:{props.createDate}</div>
+      </div>
+    </div>
+  );
+};
+
+export default SkillDetailHeader;

--- a/view/next-project/src/components/common/SkillDetailHeader/SkillDetailHeader.tsx
+++ b/view/next-project/src/components/common/SkillDetailHeader/SkillDetailHeader.tsx
@@ -12,9 +12,6 @@ const SkillDetailHeader = (props: Props) => {
   return (
     <div className={s.HeaderContainer}>
       <div className={s.TitleContainer}>{props.skillName}</div>
-      <div className={s.TextContainer}>
-        <div className={s.DescriptionContainer}>Create Date:{props.createDate}</div>
-      </div>
     </div>
   );
 };

--- a/view/next-project/src/components/common/SkillDetailHeader/index.ts
+++ b/view/next-project/src/components/common/SkillDetailHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SkillDetailHeader';

--- a/view/next-project/src/components/common/SkillEditModal.tsx
+++ b/view/next-project/src/components/common/SkillEditModal.tsx
@@ -9,6 +9,16 @@ import Button from '@components/common/TestButton';
 interface ModalProps {
   isOpen: boolean;
   setIsOpen: Function;
+  skillCategory: SkillCategory;
+}
+
+interface SkillCategory {
+  id: number;
+  name: string;
+  detail: string;
+  category_id: number;
+  category_name: string;
+  created_at: string;
 }
 
 type Skill = {
@@ -84,6 +94,7 @@ const SkillEditModal: FC<ModalProps> = (props) => {
       <div>
         <h3>Category</h3>
         <select defaultValue={formData.category_id} onChange={handler('category_id')}>
+          <option value=''>{props.skillCategory.category_name}</option>
           {categories.map((data: Category) => (
             <option key={data.id} value={data.id}>
               {data.name}

--- a/view/next-project/src/components/common/SkillEditModal.tsx
+++ b/view/next-project/src/components/common/SkillEditModal.tsx
@@ -1,0 +1,106 @@
+import React, {FC, useEffect, useState} from 'react';
+import {useRouter} from 'next/router';
+import ReactMarkdown from "react-markdown";
+import gfm from "remark-gfm";
+import {get, put} from '@utils/api_methods';
+import EditModal from '@components/common/EditModal';
+import Button from '@components/common/TestButton';
+
+interface ModalProps {
+  isOpen: boolean;
+  setIsOpen: Function;
+}
+
+type Skill = {
+  name: string;
+  detail: string;
+  category_id: number;
+}
+
+type Category = {
+  id: number;
+  name: string;
+}
+
+const SkillEditModal: FC<ModalProps> = (props) => {
+  const router = useRouter();
+  const query = router.query;
+
+  const [categories, setCategories] = useState<Category[]>([{id: 0, name: ''}])
+  const [skillData, setSkillData] = useState<Skill>({name: '', detail: '', category_id: 0});
+  const [formData, setFormData] = useState({
+    name: '',
+    detail: '',
+    category_id: '',
+  });
+
+  useEffect(() => {
+    const getCategoriesUrl = process.env.CSR_API_URI + '/categories';
+    const getCategoires = async (url: string) => {
+      setCategories(await get(url));
+    };
+    getCategoires(getCategoriesUrl);
+
+    if (router.isReady) {
+      const getFormDataUrl = process.env.CSR_API_URI + '/skills/' + query.id;
+      const getFormData = async (url: string) => {
+        setFormData(await get(url));
+      };
+      getFormData(getFormDataUrl);
+      const getSkillDataUrl = process.env.CSR_API_URI + '/api/v1/skills/' + query.id;
+      const getSkillData = async (url: string) => {
+        setSkillData(await get(url));
+      };
+      getSkillData(getSkillDataUrl);
+    }
+  }, [query, router]);
+
+  const handler =
+    (input: string) => (
+      e:
+        React.ChangeEvent<HTMLInputElement>
+          | React.ChangeEvent<HTMLTextAreaElement>
+            | React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    setFormData({...formData, [input]: e.target.value});
+  };
+
+  const submitSkill = async (data: any, query: any) => {
+    const submitSkillUrl = process.env.CSR_API_URI + '/skills/' + query.id;
+    await put(submitSkillUrl, data);
+  };
+
+  return (
+    <EditModal show={props.isOpen} setShow={props.setIsOpen}>
+      <h2>Edit Skill</h2>
+      <div>
+        <h3>Name</h3>
+        <input type='text' placeholder='Input' value={formData.name} onChange={handler('name')}/>
+      </div>
+      <div>
+        <h3>Detail</h3>
+        <input type='text' placeholder='Input' value={formData.detail} onChange={handler('detail')}/>
+      </div>
+      <div>
+        <h3>Category</h3>
+        <select defaultValue={formData.category_id} onChange={handler('category_id')}>
+          {categories.map((data: Category) => (
+            <option key={data.id} value={data.id}>
+              {data.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <Button
+        onClick={() => {
+          submitSkill(formData, query);
+          router.reload();
+        }}
+      >
+        Submit
+      </Button>
+      </EditModal>
+  );
+};
+
+export default SkillEditModal;

--- a/view/next-project/src/pages/skills/[id].tsx
+++ b/view/next-project/src/pages/skills/[id].tsx
@@ -1,0 +1,121 @@
+import React, {useState} from 'react';
+import ReactMarkdown from "react-markdown";
+import gfm from "remark-gfm";
+import {get} from '@utils/api_methods';
+import MainLayout from '@components/layout/MainLayout';
+import FlatCard from '@components/common/FlatCard';
+import SkillDetailHeader from '@components/common/SkillDetailHeader';
+import styled from 'styled-components';
+import Button from '@components/common/BackButton';
+import Row from '@components/layout/RowLayout';
+import EditButton from '@components/common/EditButton';
+import DeleteButton from '@components/common/DeleteButton';
+import SkillEditModal from "@components/common/SkillEditModal";
+import SkillDeleteModal from "@components/common/SkillDeleteModal";
+
+interface Props {
+  id: number;
+  name: string;
+  detail: string;
+  category_id: number;
+  category_name: string;
+  created_at: string;
+}
+
+export async function getServerSideProps({params}: any) {
+  const id = params.id;
+  const getSkillUrl = process.env.SSR_API_URI + '/api/v1/get_skill_for_view/' + id;
+  const getRes = await get(getSkillUrl);
+  console.log(getRes);
+  return {
+    props: getRes,
+  };
+}
+
+export default function Page(props: Props) {
+  const SkillContentsContainer = styled.div`
+  width: 100%;
+  `;
+  const SkillContentsTitle = styled.div`
+  font-size: 2.8rem;
+  padding-bottom: 1.2rem;
+  `;
+  const SkillContents = styled.div`
+  font-size: 1.6rem;
+  padding-bottom: 3rem;
+  `;
+  const ParentButtonContainer = styled.div`
+  position: relative;
+  width: 100%;
+  `;
+  const ChildButtonContainer = styled.div`
+  position: absolute;
+  bottom: 50px;
+  left: -40px;
+  `;
+
+  const formatDate = (date: string) => {
+    let datetime = date.replace('T', ' ');
+    const datetime2 = datetime.substring(0, datetime.length - 5);
+    return datetime2;
+  };
+
+  const [isOpenEditSkillModal, setIsOpenEditSkillModal] = useState(false);
+  const [isOpenDeleteSkillModal, setIsOpenDeleteSkillModal] = useState(false);
+  const openEditSkillModal = (isOpenEditSkillModal: boolean) => {
+    if (isOpenEditSkillModal) {
+      return (
+        <>
+          <SkillEditModal isOpen={isOpenEditSkillModal} setIsOpen={setIsOpenEditSkillModal}/>
+        </>
+      );
+    }
+  };
+  const openDeleteSkillModal = (isOpenDeleteSkillModal: boolean) => {
+    if (isOpenDeleteSkillModal) {
+      return (
+        <>
+          <SkillDeleteModal isOpen={isOpenDeleteSkillModal} setIsOpen={setIsOpenDeleteSkillModal}/>
+        </>
+      );
+    }
+  };
+
+  return (
+    <MainLayout>
+      <ParentButtonContainer>
+        <SkillDetailHeader
+          skillName={props.name}
+          createDate={formatDate(props.created_at)}
+        />
+        <FlatCard width='100%'>
+          <Row gap="3rem" justify="end">
+            <EditButton onClick={() => setIsOpenEditSkillModal(!isOpenEditSkillModal)}/>
+            {openEditSkillModal(isOpenEditSkillModal)}
+            <DeleteButton onClick={() => setIsOpenDeleteSkillModal(!isOpenDeleteSkillModal)}/>
+            {openDeleteSkillModal(isOpenDeleteSkillModal)}
+          </Row>
+          <SkillContentsContainer>
+            <SkillContentsTitle>
+              Category
+              <hr/>
+            </SkillContentsTitle>
+            <SkillContents>
+              <ReactMarkdown remarkPlugins={[gfm]} unwrapDisallowed={false}>
+                {props.category_name}
+              </ReactMarkdown>
+            </SkillContents>
+            <SkillContentsTitle>
+              Detail
+              <hr/>
+            </SkillContentsTitle>
+            <SkillContents>{props.detail}</SkillContents>
+          </SkillContentsContainer>
+        </FlatCard>
+        <ChildButtonContainer>
+          <Button/>
+        </ChildButtonContainer>
+      </ParentButtonContainer>
+    </MainLayout>
+  );
+}

--- a/view/next-project/src/pages/skills/[id].tsx
+++ b/view/next-project/src/pages/skills/[id].tsx
@@ -66,7 +66,7 @@ export default function Page(props: Props) {
     if (isOpenEditSkillModal) {
       return (
         <>
-          <SkillEditModal isOpen={isOpenEditSkillModal} setIsOpen={setIsOpenEditSkillModal}/>
+          <SkillEditModal isOpen={isOpenEditSkillModal} setIsOpen={setIsOpenEditSkillModal} skillCategory={props}/>
         </>
       );
     }

--- a/view/next-project/src/pages/skills/index.tsx
+++ b/view/next-project/src/pages/skills/index.tsx
@@ -40,7 +40,7 @@ const Skills: React.VFC<Props> = (props) => {
         <FlatCard>
           <Table headers={headers}>
             {skills.map((skill) => (
-              <tr key={skill.id}>
+              <tr key={skill.id} onClick={() => Router.push('/skills/' + skill.id)}>
                 <td>{skill.name}</td>
                 <td>{skill.category_name}</td>
                 <td>{formatDate(skill.created_at)}</td>


### PR DESCRIPTION
スキルの個別ページの追加を行いました。

- 個別ページを作るにあたって、apiを編集し新たに`get_skill_for_view`を追加しました。
- 個別ページを作りました。ヘッダーはタグがない分Create Dateの下にpaddingを入れて、ヘッダーとフラットカードが密接しないようにしました。
- 各スキルの編集・削除ボタン及びモーダルを追加しました。たぶんちゃんと動作します。