### PR TITLE
[mod]selectの選択肢が重複する(#98)

### DIFF
--- a/view/next-project/src/components/common/RecordEditModal.tsx
+++ b/view/next-project/src/components/common/RecordEditModal.tsx
@@ -9,36 +9,6 @@ import Button from '@components/common/TestButton';
 interface ModalProps {
   isOpen: boolean;
   setIsOpen: Function;
-  defaultParams: DefaultParams;
-}
-
-interface CurriculumDetail {
-  id: number;
-  title: string;
-  content: string;
-  homework: string;
-  skill_id: number;
-  created_at: string;
-  updated_at: string;
-}
-
-interface RecordDetail {
-  id: number;
-  title: string;
-  content: string;
-  homework: string;
-  user_id: number;
-  curriculum_id: number;
-  created_at: string;
-  updated_at: string;
-}
-
-interface DefaultParams {
-  curriculum: CurriculumDetail;
-  record: RecordDetail;
-  teacher: string;
-  user: string;
-  skill: string;
 }
 
 interface Teacher {
@@ -206,7 +176,7 @@ const RecordEditModal: FC<ModalProps> = (props) => {
         <h3>Curriculum</h3>
         <select defaultValue={formData.curriculum_id} onChange={handler('curriculum_id')}>
           {curriculums.map((data: Curriculum) => {
-            if (data.id == props.defaultParams.curriculum.id) {
+            if (data.id == teacherData.user_id) {
               return(
                 <option key={data.id} value={data.id} selected>
                   {data.title}
@@ -219,10 +189,6 @@ const RecordEditModal: FC<ModalProps> = (props) => {
                 </option>
               )
             }
-
-            <option key={data.id} value={data.id}>
-              {data.title}
-            </option>
           })}
         </select>
       </div>

--- a/view/next-project/src/components/common/RecordEditModal.tsx
+++ b/view/next-project/src/components/common/RecordEditModal.tsx
@@ -53,7 +53,7 @@ interface User {
 }
 
 interface Curriculum {
-  id: string;
+  id: number | string;
   title: string;
 }
 
@@ -185,23 +185,45 @@ const RecordEditModal: FC<ModalProps> = (props) => {
       <div>
         <h3>Teacher</h3>
         <select defaultValue={teacherData.user_id} onChange={teacherHandler('user_id', query)}>
-          <option value=''>{props.defaultParams.teacher}</option>
-          {users.map((data: User) => (
-            <option key={data.id} value={data.id}>
-              {data.name}
-            </option>
-          ))}
+          {users.map((data: User) => {
+            if (data.id == teacherData.user_id) {
+              return(
+                <option key={data.id} value={data.id} selected>
+                  {data.name}
+                </option>
+              )
+            }else{
+              return(
+                <option key={data.id} value={data.id}>
+                  {data.name}
+                </option>
+              )
+            }
+          })}
         </select>
       </div>
       <div>
         <h3>Curriculum</h3>
         <select defaultValue={formData.curriculum_id} onChange={handler('curriculum_id')}>
-          <option value=''>{props.defaultParams.curriculum.title}</option>
-          {curriculums.map((data: Curriculum) => (
+          {curriculums.map((data: Curriculum) => {
+            if (data.id == props.defaultParams.curriculum.id) {
+              return(
+                <option key={data.id} value={data.id} selected>
+                  {data.title}
+                </option>
+              )
+            }else{
+              return(
+                <option key={data.id} value={data.id}>
+                  {data.title}
+                </option>
+              )
+            }
+
             <option key={data.id} value={data.id}>
               {data.title}
             </option>
-          ))}
+          })}
         </select>
       </div>
       <Button

--- a/view/next-project/src/components/common/RecordEditModal.tsx
+++ b/view/next-project/src/components/common/RecordEditModal.tsx
@@ -1,8 +1,8 @@
-import React, {FC, useEffect, useState} from 'react';
-import {useRouter} from 'next/router';
-import ReactMarkdown from "react-markdown";
-import gfm from "remark-gfm";
-import {get, put} from '@utils/api_methods';
+import React, { FC, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import ReactMarkdown from 'react-markdown';
+import gfm from 'remark-gfm';
+import { get, put } from '@utils/api_methods';
 import EditModal from '@components/common/EditModal';
 import Button from '@components/common/TestButton';
 
@@ -45,16 +45,16 @@ const RecordEditModal: FC<ModalProps> = (props) => {
   const router = useRouter();
   const query = router.query;
 
-  const [curriculums, setCurriculums] = useState<Curriculum[]>([{id: '', title: ''}]);
-  const [users, setUsers] = useState<User[]>([{id: '', name: ''}]);
-  const [teacherData, setTeacherData] = useState<Teacher>({id: '', user_id: '', record_id: ''});
+  const [curriculums, setCurriculums] = useState<Curriculum[]>([{ id: '', title: '' }]);
+  const [users, setUsers] = useState<User[]>([{ id: '', name: '' }]);
+  const [teacherData, setTeacherData] = useState<Teacher>({ id: '', user_id: '', record_id: '' });
   const [record, setRecord] = useState<RecordCurriculumTeacher>({
     record: null,
     curriculum: null,
     curriculum_title: '',
     teacher: '',
     user: '',
-    skill: ''
+    skill: '',
   });
   const [formData, setFormData] = useState({
     title: '',
@@ -99,16 +99,17 @@ const RecordEditModal: FC<ModalProps> = (props) => {
   }, [query, router]);
 
   const handler =
-    (input: string) => (
+    (input: string) =>
+    (
       e:
-        React.ChangeEvent<HTMLInputElement>
-          | React.ChangeEvent<HTMLTextAreaElement>
-            | React.ChangeEvent<HTMLSelectElement>,
-  ) => {
-    setFormData({...formData, [input]: e.target.value});
-  };
-  const teacherHandler = (input: string, query: any) => (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setTeacherData({id: "1", user_id: e.target.value, record_id: query.id.toString()});
+        | React.ChangeEvent<HTMLInputElement>
+        | React.ChangeEvent<HTMLTextAreaElement>
+        | React.ChangeEvent<HTMLSelectElement>,
+    ) => {
+      setFormData({ ...formData, [input]: e.target.value });
+    };
+  const teacherHandler = (query: any) => (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setTeacherData({ id: '1', user_id: e.target.value, record_id: query.id.toString() });
   };
 
   const submitRecord = async (data: any, query: any) => {
@@ -116,8 +117,7 @@ const RecordEditModal: FC<ModalProps> = (props) => {
     await put(submitRecordUrl, data);
   };
 
-  const submitTeacher = async (data: any, query: any) => {
-    console.log(data);
+  const submitTeacher = async (data: any) => {
     const submitTeacherUrl = process.env.CSR_API_URI + '/teachers/' + teacherData.id;
     await put(submitTeacherUrl, data);
     router.reload();
@@ -128,12 +128,12 @@ const RecordEditModal: FC<ModalProps> = (props) => {
       <h2>Edit Record</h2>
       <div>
         <h3>Record Name</h3>
-        <input type='text' placeholder='Input' value={formData.title} onChange={handler('title')}/>
+        <input type='text' placeholder='Input' value={formData.title} onChange={handler('title')} />
       </div>
       <div>
         <h3>Contents</h3>
         <div>
-          <textarea placeholder='Input' value={formData.content} onChange={handler('content')}/>
+          <textarea placeholder='Input' value={formData.content} onChange={handler('content')} />
           <div>
             <ReactMarkdown remarkPlugins={[gfm]} unwrapDisallowed={false}>
               {formData.content}
@@ -144,7 +144,7 @@ const RecordEditModal: FC<ModalProps> = (props) => {
       <div>
         <h3>Homework</h3>
         <div>
-          <textarea placeholder='Input' value={formData.homework} onChange={handler('homework')}/>
+          <textarea placeholder='Input' value={formData.homework} onChange={handler('homework')} />
           <div>
             <ReactMarkdown remarkPlugins={[gfm]} unwrapDisallowed={false}>
               {formData.homework}
@@ -154,20 +154,20 @@ const RecordEditModal: FC<ModalProps> = (props) => {
       </div>
       <div>
         <h3>Teacher</h3>
-        <select defaultValue={teacherData.user_id} onChange={teacherHandler('user_id', query)}>
+        <select defaultValue={teacherData.user_id} onChange={teacherHandler(query)}>
           {users.map((data: User) => {
             if (data.id == teacherData.user_id) {
-              return(
+              return (
                 <option key={data.id} value={data.id} selected>
                   {data.name}
                 </option>
-              )
-            }else{
-              return(
+              );
+            } else {
+              return (
                 <option key={data.id} value={data.id}>
                   {data.name}
                 </option>
-              )
+              );
             }
           })}
         </select>
@@ -176,18 +176,18 @@ const RecordEditModal: FC<ModalProps> = (props) => {
         <h3>Curriculum</h3>
         <select defaultValue={formData.curriculum_id} onChange={handler('curriculum_id')}>
           {curriculums.map((data: Curriculum) => {
-            if (data.id == teacherData.user_id) {
-              return(
+            if (data.id == formData.curriculum_id) {
+              return (
                 <option key={data.id} value={data.id} selected>
                   {data.title}
                 </option>
-              )
-            }else{
-              return(
+              );
+            } else {
+              return (
                 <option key={data.id} value={data.id}>
                   {data.title}
                 </option>
-              )
+              );
             }
           })}
         </select>
@@ -195,12 +195,12 @@ const RecordEditModal: FC<ModalProps> = (props) => {
       <Button
         onClick={() => {
           submitRecord(formData, query);
-          submitTeacher(teacherData, query);
+          submitTeacher(teacherData);
         }}
       >
         Submit
       </Button>
-      </EditModal>
+    </EditModal>
   );
 };
 

--- a/view/next-project/src/components/common/SkillEditModal.tsx
+++ b/view/next-project/src/components/common/SkillEditModal.tsx
@@ -38,6 +38,7 @@ const SkillEditModal: FC<ModalProps> = (props) => {
 
   const [categories, setCategories] = useState<Category[]>([{id: 0, name: ''}])
   const [skillData, setSkillData] = useState<Skill>({name: '', detail: '', category_id: 0});
+  
   const [formData, setFormData] = useState({
     name: '',
     detail: '',
@@ -94,12 +95,21 @@ const SkillEditModal: FC<ModalProps> = (props) => {
       <div>
         <h3>Category</h3>
         <select defaultValue={formData.category_id} onChange={handler('category_id')}>
-          <option value=''>{props.skillCategory.category_name}</option>
-          {categories.map((data: Category) => (
-            <option key={data.id} value={data.id}>
-              {data.name}
-            </option>
-          ))}
+          {categories.map((data: Category) => {
+            if (data.id == props.skillCategory.category_id){
+              return(
+                <option key={data.id} value={data.id} selected>
+                  {data.name}
+                </option>
+              )
+            }else{
+              return(
+                <option key={data.id} value={data.id}>
+                  {data.name}
+                </option>
+              )
+            }
+          })}
         </select>
       </div>
       <Button

--- a/view/next-project/src/components/common/SkillEditModal.tsx
+++ b/view/next-project/src/components/common/SkillEditModal.tsx
@@ -9,16 +9,6 @@ import Button from '@components/common/TestButton';
 interface ModalProps {
   isOpen: boolean;
   setIsOpen: Function;
-  skillCategory: SkillCategory;
-}
-
-interface SkillCategory {
-  id: number;
-  name: string;
-  detail: string;
-  category_id: number;
-  category_name: string;
-  created_at: string;
 }
 
 type Skill = {
@@ -38,7 +28,6 @@ const SkillEditModal: FC<ModalProps> = (props) => {
 
   const [categories, setCategories] = useState<Category[]>([{id: 0, name: ''}])
   const [skillData, setSkillData] = useState<Skill>({name: '', detail: '', category_id: 0});
-  
   const [formData, setFormData] = useState({
     name: '',
     detail: '',
@@ -96,7 +85,7 @@ const SkillEditModal: FC<ModalProps> = (props) => {
         <h3>Category</h3>
         <select defaultValue={formData.category_id} onChange={handler('category_id')}>
           {categories.map((data: Category) => {
-            if (data.id == props.skillCategory.category_id){
+            if (data.id == skillData.category_id) {
               return(
                 <option key={data.id} value={data.id} selected>
                   {data.name}

--- a/view/next-project/src/pages/records/[id].tsx
+++ b/view/next-project/src/pages/records/[id].tsx
@@ -85,7 +85,7 @@ export default function Page(props: Props) {
     if (isOpenEditRecordModal) {
       return (
         <>
-          <RecordEditModal isOpen={isOpenEditRecordModal} setIsOpen={setIsOpenEditRecordModal} defaultParams={props} />
+          <RecordEditModal isOpen={isOpenEditRecordModal} setIsOpen={setIsOpenEditRecordModal} />
         </>
       );
     }

--- a/view/next-project/src/pages/skills/[id].tsx
+++ b/view/next-project/src/pages/skills/[id].tsx
@@ -66,7 +66,7 @@ export default function Page(props: Props) {
     if (isOpenEditSkillModal) {
       return (
         <>
-          <SkillEditModal isOpen={isOpenEditSkillModal} setIsOpen={setIsOpenEditSkillModal} skillCategory={props}/>
+          <SkillEditModal isOpen={isOpenEditSkillModal} setIsOpen={setIsOpenEditSkillModal} />
         </>
       );
     }


### PR DESCRIPTION
skillとrecordのselectの重複を解消しました。

selectの選択肢が重複してしまっているので、mapの手前でoptionを追加するのをやめ、該当した選択を既に選択しておくようにmap内で完結するようにしました。