### PR TITLE
レコードの通知改善とレコード追加時に teacher と student を選択できるようにUIを修正

### DIFF
--- a/api/app/controllers/records_controller.rb
+++ b/api/app/controllers/records_controller.rb
@@ -16,8 +16,10 @@ class RecordsController < ApplicationController
   # POST /records
   def create
     @record = Record.new(record_params)
-
+    
     if @record.save
+      @teacher = Teacher.create(user_id: teacher_params[:user_id], record_id: @record.id)
+
       render json: @record, status: :created, location: @record
     else
       render json: @record.errors, status: :unprocessable_entity
@@ -37,9 +39,10 @@ class RecordsController < ApplicationController
       「#{@record.user.name}」のRecordが追加されました
       Link：#{ENV['RECORD_BASE_URL'].to_s + '/records/' + @record.id.to_s}
       ーーーーーーーーーーーーーーーー
-      Title：#{@record.title}
-      Tech: #{@record.curriculum.skill.name}
-      Curriculum: #{@record.curriculum.title}
+      Title： #{@record.title}
+      Teacher： #{@record.teacher.user.name}
+      Skill： #{@record.curriculum.skill.name}
+      Curriculum： #{@record.curriculum.title}
       Content：
       #{@record.content}
       ーーーーーーーーーーーーーーーー
@@ -73,6 +76,9 @@ class RecordsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def record_params
-    params.permit(:title, :content, :homework, :user_id, :curriculum_id)
+    params.require(:record).permit(:title, :content, :homework, :user_id, :curriculum_id)
+  end
+  def teacher_params
+    params.require(:teacher).permit(:user_id, :record_id)
   end
 end

--- a/view/next-project/src/components/common/RecordAddModal/RecordAddModal.tsx
+++ b/view/next-project/src/components/common/RecordAddModal/RecordAddModal.tsx
@@ -111,7 +111,8 @@ const RecordAddModal: FC<ModalProps> = (props) => {
     ) => {
       setRecordData({ ...recordData, [input]: e.target.value });
     };
-  const teacherHandler = (input: string) => (e: React.ChangeEvent<HTMLSelectElement>) => {
+
+  const teacherHandler = () => (e: React.ChangeEvent<HTMLSelectElement>) => {
     setTeacherData({ ...teacherData, user_id: e.target.value });
   };
 
@@ -128,19 +129,20 @@ const RecordAddModal: FC<ModalProps> = (props) => {
   const submitRecord = async (recordData: any, teacherData: any) => {
     const submitRecordUrl = process.env.CSR_API_URI + '/records';
     const submitData = {
-      title: recordData.title,
-      content: recordMarkdown,
-      homework: homeworkMarkdown,
-      user_id: recordData.user_id,
-      curriculum_id: recordData.curriculum_id,
+      record: {
+        title: recordData.title,
+        content: recordMarkdown,
+        homework: homeworkMarkdown,
+        user_id: recordData.user_id,
+        curriculum_id: recordData.curriculum_id,
+      },
+      teacher: {
+        user_id: teacherData.user_id,
+        record_id: 1,
+      },
     };
-    console.log('postdata: ', submitData);
     const req = await post(submitRecordUrl, submitData);
     const res = await req.json();
-    console.log('res: ', res);
-    const submitTeacherUrl = process.env.CSR_API_URI + '/teachers';
-    await post(submitTeacherUrl, { user_id: teacherData.user_id, record_id: res.id });
-
     const getRecordUrl = process.env.CSR_API_URI + '/api/v1/get_record_for_index_reload/' + res.id;
     const getRes = await get(getRecordUrl);
     const newRecord: Record = getRes[0];
@@ -174,9 +176,29 @@ const RecordAddModal: FC<ModalProps> = (props) => {
           <SimpleMde value={homeworkMarkdown} onChange={homeworkMarkdownHandler} className={s.homeworkMde} />
           <h3 className={s.contentsTitle}>Teacher</h3>
           <div className={s.modalContentContents}>
-            <select defaultValue={teacherData.user_id} onChange={teacherHandler(query)}>
+            <select defaultValue={teacherData.user_id} onChange={teacherHandler()}>
               {users.map((data: User) => {
                 if (data.id == teacherData.user_id) {
+                  return (
+                    <option key={data.id} value={data.id} selected>
+                      {data.name}
+                    </option>
+                  );
+                } else {
+                  return (
+                    <option key={data.id} value={data.id}>
+                      {data.name}
+                    </option>
+                  );
+                }
+              })}
+            </select>
+          </div>
+          <h3 className={s.contentsTitle}>Student</h3>
+          <div className={s.modalContentContents}>
+            <select defaultValue={recordData.user_id} onChange={recordHandler('user_id')}>
+              {users.map((data: User) => {
+                if (data.id == recordData.user_id) {
                   return (
                     <option key={data.id} value={data.id} selected>
                       {data.name}


### PR DESCRIPTION
# 概要
ref: #127
ref: #129 

# 実装したこと
#127
- 原因： student は自動的に record 作成者になるように設定していたが、最近の方針では teacher がレコードを残すようになっっているため、 student と teacher が重複する問題が起こっていた
- student と teacher の両方を選択するようにUIを変更

#129 
- slack通知時にteacherも一緒に表示されるように変更
- Slack通知のアイコンをNUTMEGのロゴにして、名前を「NUTMEG-Seedsに変更」
- Record追加時の処理も合わせて変更
  - before
    - レコード追加 -> そのレコードの id を res から取得 -> teacher に post -> レコード取得
    - 変更した理由： フロントから2回APIを叩くのは非効率であり、処理の速度による危険性も比較的高いと感じたため 
  - after
    - record に teacher の user_id を含めたデータを post レコードを取得
 
# テスト項目
- [x] record 追加時にstudent と teacher のセレクトボックスが表示され、選択できるか
- [x] record 追加時に、作成したレコード通りのデータがSlack (#notification-record-local) に通知されるか
- [x] Slack (#notification-record-local) に通知されるデータは teacher のデータも含まれているか
- [x] 作成したレコードの詳細ページに遷移すると、作成したレコード通りのデータが表示されているか