### PR TITLE
[add]章テーブルの作成と紐付け(#143)

### DIFF
--- a/api/app/controllers/api/v1/curriculums_api_controller.rb
+++ b/api/app/controllers/api/v1/curriculums_api_controller.rb
@@ -14,4 +14,19 @@ class Api::V1::CurriculumsApiController < ApplicationController
     @curriculum = Curriculum.with_skills_and_records(params[:id])
     render json: @curriculum
   end
+
+  def get_curriculums_chapter_for_index
+    @curriculums = Curriculum.with_chapters
+    render json: @curriculums
+  end
+
+  def get_curriculum_chapter_for_reload_index
+    @curriculums = Curriculum.with_chapter(params[:id])
+    render json: @curriculums
+  end
+
+  def get_curriculum_chapter_for_view
+    @curriculum = Curriculum.with_chapters_and_records(params[:id])
+    render json: @curriculum
+  end
 end

--- a/api/app/controllers/chapters_controller.rb
+++ b/api/app/controllers/chapters_controller.rb
@@ -1,0 +1,52 @@
+class ChaptersController < ApplicationController
+  before_action :set_chapter, only: [:show, :update, :destroy]
+
+  # GET /chapters
+  def index
+    @chapters = Chapter.all
+
+    render json: @chapters
+  end
+
+  # GET /chapters/1
+  def show
+    render json: @chapter
+  end
+
+  # POST /chapters
+  def create
+    @chapter = Chapter.new(chapter_params)
+
+    if @chapter.save
+      render json: @chapter, status: :created, location: @chapter
+    else
+      render json: @chapter.errors, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH/PUT /chapters/1
+  def update
+    if @chapter.update(chapter_params)
+      render json: @chapter
+    else
+      render json: @chapter.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /chapters/1
+  def destroy
+    @chapter.destroy
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_chapter
+      @chapter = Chapter.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def chapter_params
+      params.require(:chapter).permit(:title, :content, :homework, :curriculum_id)
+    end
+
+end

--- a/api/app/controllers/curriculums_controller.rb
+++ b/api/app/controllers/curriculums_controller.rb
@@ -53,7 +53,7 @@ class CurriculumsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def curriculum_params
-      params.require(:curriculum).permit(:id, :title, :content, :homework, :created_at, :updated_at)
+      params.require(:curriculum).permit(:id, :title, :graduation_assignment, :created_at, :updated_at)
     end
 
     # curriculum_skillが複数あるので、配列で受け取る
@@ -62,4 +62,10 @@ class CurriculumsController < ApplicationController
         curriculum_skill.permit(:curriculum_id, :skill_id)
       end
     end
+
+    # def curriculum_chapter_params
+    #   params.require(:chapter).map do |chapter|
+    #     chapter.permit(:curriculum_id)
+    #   end
+    # end
 end

--- a/api/app/models/chapter.rb
+++ b/api/app/models/chapter.rb
@@ -1,0 +1,3 @@
+class Chapter < ApplicationRecord
+  belongs_to :curriculum
+end

--- a/api/app/models/curriculum.rb
+++ b/api/app/models/curriculum.rb
@@ -1,6 +1,7 @@
 class Curriculum < ApplicationRecord
   has_many :curriculum_skills, dependent: :destroy
   has_many :skills, through: :curriculum_skills
+  has_many :chapters, dependent: :destroy
   has_many :records
 
   def self.with_skills
@@ -63,5 +64,73 @@ class Curriculum < ApplicationRecord
         }
       }
   end
+
+  def self.with_chapters
+    @records = Curriculum.eager_load(:chapters)
+      .map{
+        |curriculum|
+        {
+          "curriculum": curriculum,
+          "chapters": curriculum.chapters.map{
+            |chapter|
+            {
+              "id": chapter.id,
+              "title": chapter.title,
+              "content": chapter.content,
+              "homework": chapter.homework,
+            }
+          }
+        }
+      }
+  end
+
+  def self.with_chapter(curriculum_id)
+    @record = Curriculum.eager_load(:chapters).where(curriculums: {id: curriculum_id})
+      .map{
+        |curriculum|
+        {
+          "curriculum": curriculum,
+          "chapters": curriculum.chapters.map{
+            |chapter|
+            {
+              "id": chapter.id,
+              "title": chapter.title,
+              "content": chapter.content,
+              "homework": chapter.homework,
+            }
+          }
+        }
+      }
+  end
+
+  def self.with_chapters_and_records(curriculum_id)
+    @record = Curriculum.eager_load(:chapters, :records).where(curriculums: {id: curriculum_id})
+      .map{
+        |curriculum|
+        {
+          "curriculum": curriculum,
+          "chapter": curriculum.chapters.map{
+            |chapter|
+            {
+              "id": chapter.id,
+              "title": chapter.title,
+              "content": chapter.content,
+              "homework": chapter.homework,
+            }
+          },
+          "records": curriculum.records.map{
+            |record|
+            {
+              "id": record.id,
+              "title": record.title,
+              "user": record.user.name,
+              "created_at": record.created_at,
+              "updated_at": record.updated_at,
+            }
+          }
+        }
+      }
+  end
+
 
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   resources :categories
   resources :teachers
   resources :records
+  resources :chapters
   mount_devise_token_auth_for 'User', at: 'auth'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace 'api' do
@@ -46,6 +47,9 @@ Rails.application.routes.draw do
       get "/get_curriculum_for_view/:id" => "curriculums_api#get_curriculum_for_view"
       get "/get_curriculums_for_index" => "curriculums_api#get_curriculums_for_index"
       get "/get_curriculum_for_reload_index/:id" => "curriculums_api#get_curriculum_for_reload_index"
+      get "/get_curriculum_chapter_for_view/:id" => "curriculums_api#get_curriculum_chapter_for_view"
+      get "/get_curriculums_chapter_for_index" => "curriculums_api#get_curriculums_chapter_for_index"
+      get "/get_curriculum_chapter_for_reload_index/:id" => "curriculums_api#get_curriculum_chapter_for_reload_index"
 
       # project
       get "/get_project_for_view/:id" => "projects_api#get_project_for_view"

--- a/api/db/fixtures/chapter.rb
+++ b/api/db/fixtures/chapter.rb
@@ -1,0 +1,6 @@
+Chapter.seed( :id,
+  { id: 1, title: 'TypeScript 環境構築', content: 'TypeScriptの環境を構築する', homework: 'test_homework_1', curriculum_id: 1},
+  { id: 2, title: 'TypeScript ページ遷移', content: 'TypeScriptのページ遷移を理解する', homework: 'test_homework_2', curriculum_id: 1},
+  { id: 3, title: 'React勉強会', content: 'Reactを用いたフロントエンドの実装を習得する', homework: 'test_homework', curriculum_id: 2},
+  { id: 4, title: 'インターフェース勉強会', content: 'GoとGraphQLサーバーの実装を習得する', homework: 'test_homework', curriculum_id: 3},
+)

--- a/api/db/fixtures/curriculum.rb
+++ b/api/db/fixtures/curriculum.rb
@@ -1,6 +1,6 @@
 Curriculum.seed( :id,
-  { id: 1, title: 'TypeScript勉強会', graduation_assignment: 'チャットアプリを作成', skill_ids: 1},
-  { id: 2, title: 'Go勉強会', graduation_assignment: '家計簿アプリを作成', skill_ids: 1},
-  { id: 3, title: 'React勉強会', graduation_assignment: 'Webアプリを作成', skill_ids: 2 },
-  { id: 4, title: 'インターフェース勉強会', graduation_assignment: 'ポートフォリオを作成', skill_ids: 3 },
+  { id: 1, title: 'TypeScript勉強会', graduation_assignment: 'チャットアプリを作成'},
+  { id: 2, title: 'Go勉強会', graduation_assignment: '家計簿アプリを作成'},
+  { id: 3, title: 'React勉強会', graduation_assignment: 'Webアプリを作成' },
+  { id: 4, title: 'インターフェース勉強会', graduation_assignment: 'ポートフォリオを作成' },
 )

--- a/api/db/fixtures/curriculum.rb
+++ b/api/db/fixtures/curriculum.rb
@@ -1,6 +1,6 @@
 Curriculum.seed( :id,
-  { id: 1, title: 'TypeScript勉強会', content: 'TypeScriptを用いたフロントエンド，バックエンドの実装を習得する', homework: 'test_homework'},
-  { id: 2, title: 'Go勉強会', content: 'Goを用いたバックエンドの実装を習得する', homework: 'test_homework'},
-  { id: 3, title: 'React勉強会', content: 'Reactを用いたフロントエンドの実装を習得する', homework: 'test_homework'},
-  { id: 4, title: 'インターフェース勉強会', content: 'GoとGraphQLサーバーの実装を習得する', homework: 'test_homework'},
+  { id: 1, title: 'TypeScript勉強会', graduation_assignment: 'チャットアプリを作成', skill_ids: 1},
+  { id: 2, title: 'Go勉強会', graduation_assignment: '家計簿アプリを作成', skill_ids: 1},
+  { id: 3, title: 'React勉強会', graduation_assignment: 'Webアプリを作成', skill_ids: 2 },
+  { id: 4, title: 'インターフェース勉強会', graduation_assignment: 'ポートフォリオを作成', skill_ids: 3 },
 )

--- a/api/db/migrate/20221204080908_create_chapters.rb
+++ b/api/db/migrate/20221204080908_create_chapters.rb
@@ -1,0 +1,13 @@
+class CreateChapters < ActiveRecord::Migration[6.1]
+  def change
+    create_table :chapters do |t|
+      t.string :title
+      t.text :content
+      t.text :homework
+      t.integer :skill_ids
+      t.integer :curriculum_id
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/migrate/20221208044517_remove_skill_ids_from_chapters.rb
+++ b/api/db/migrate/20221208044517_remove_skill_ids_from_chapters.rb
@@ -1,0 +1,5 @@
+class RemoveSkillIdsFromChapters < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :chapters, :skill_ids, :integer
+  end
+end

--- a/api/db/migrate/20221210060519_remove_content_from_curriculums.rb
+++ b/api/db/migrate/20221210060519_remove_content_from_curriculums.rb
@@ -1,0 +1,6 @@
+class RemoveContentFromCurriculums < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :curriculums, :content, :text
+    remove_column :curriculums, :homework, :text
+  end
+end

--- a/api/db/migrate/20221210060933_add_graduation_assignment_to_curriculums.rb
+++ b/api/db/migrate/20221210060933_add_graduation_assignment_to_curriculums.rb
@@ -1,0 +1,5 @@
+class AddGraduationAssignmentToCurriculums < ActiveRecord::Migration[6.1]
+  def change
+    add_column :curriculums, :graduation_assignment, :text
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_16_043827) do
+ActiveRecord::Schema.define(version: 2022_12_10_060933) do
 
   create_table "bureaus", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
@@ -24,6 +24,15 @@ ActiveRecord::Schema.define(version: 2022_07_16_043827) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "chapters", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.text "homework"
+    t.integer "curriculum_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "curriculum_skills", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "curriculum_id"
     t.integer "skill_id"
@@ -33,11 +42,10 @@ ActiveRecord::Schema.define(version: 2022_07_16_043827) do
 
   create_table "curriculums", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"
-    t.text "content"
-    t.text "homework"
     t.integer "skill_ids"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "graduation_assignment"
   end
 
   create_table "departments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
   # 定期実行用コンテナ
   cron:
-    image: nutmeg-seeds-seeds_api:latest
+    image: nutmeg-seeds_seeds_api:latest
     command: >
       sh -c "whenever --update-cron &&
       cron -f -l 2"

--- a/view/next-project/src/pages/curriculums/index.tsx
+++ b/view/next-project/src/pages/curriculums/index.tsx
@@ -18,32 +18,52 @@ interface Curriculum {
 interface Skill {
   name: string;
 }
+interface Chapter {
+  title: string;
+  content: string;
+  homework: string;
+  curriculum_id: number;
+}
 
 interface CurriculumWithSkill {
   curriculum: Curriculum;
   skills: Skill[];
 }
 
+interface CurriculumWithChapter {
+  curriculum: Curriculum;
+  chapters: Chapter[];
+}
+
 interface Props {
   curriculumsWithSkill: CurriculumWithSkill[];
+  curriculumsWithChapter: CurriculumWithChapter[];
   skills: Skill[];
+  chapters: Chapter[];
 }
 
 export async function getServerSideProps() {
   const getCurriculumsUrl = process.env.SSR_API_URI + '/api/v1/get_curriculums_for_index';
+  const getCurriculumsChapterUrl = process.env.SSR_API_URI + '/api/v1/get_curriculums_chapter_for_index';
   const getSkillsUrl = process.env.SSR_API_URI + '/skills';
+  const getChaptersUrl = process.env.SSR_API_URI + '/chapters';
   const curriculumsJson = await get(getCurriculumsUrl);
+  const curriculumsChapterJson = await get(getCurriculumsChapterUrl);
   const skillsJson = await get(getSkillsUrl);
+  const chaptersJson = await get(getChaptersUrl);
   return {
     props: {
       curriculumsWithSkill: curriculumsJson,
+      curriculumsWithChapter: curriculumsChapterJson,
       skills: skillsJson,
+      chapters: chaptersJson,
     },
   };
 }
 
 export default function CurriculumList(props: Props) {
   const headers = ['Title', 'Skill', 'Date'];
+  const chapterHead = ['Title', 'chapter', 'Date']
 
   const formatDate = (date: string) => {
     let datetime = date.replace('T', ' ');
@@ -63,6 +83,19 @@ export default function CurriculumList(props: Props) {
                 <td>
                   {data.skills.map((skill: Skill) => {
                     return(<><span>{skill.name}</span><br/></>);
+                  })}
+                </td>
+                <td>{formatDate(data.curriculum.created_at)}</td>
+              </tr>
+            ))}
+          </Table>
+          <Table headers={chapterHead}>
+            {props.curriculumsWithChapter.map((data: CurriculumWithChapter) => (
+              <tr key={data.toString()} onClick={() => Router.push('/curriculums/' + data.curriculum.id)}>
+                <td>{data.curriculum.title}</td>
+                <td>
+                  {data.chapters.map((chapter: Chapter) => {
+                    return (<><span>{chapter.title}{chapter.homework}{chapter.content}</span><br /></>);
                   })}
                 </td>
                 <td>{formatDate(data.curriculum.created_at)}</td>


### PR DESCRIPTION
ref #143 
# 概要
章テーブルを作成し、カリキュラムと紐付けた。
# 実装内容
- 章（Chapter）のモデル、コントローラーを作成。
- カリキュラムテーブルと紐付けた。（Skillを参考に作成。）
- カリキュラムのカラムを変更。
- カラム変更に合わせてseedデータを変更。
- データを簡単にフロント表示（view/next-project/src/pages/curriculums/index.tsx）

![スクリーンショット (47)](https://user-images.githubusercontent.com/90322124/207278374-0b989097-437d-43ce-a5e7-5a4dff73e146.png)

# テスト項目

1. まず、` docker compose run --rm seeds_api rails db:migrate`,  `docker compose run --rm seeds_api rails db:seed_fu`して変更を反映させてください。
2. Chapterのデータが取得できるか、フロントに表示されているか確認してください
