### PR TITLE
[fix] chapterのスタイル崩れを修正

### DIFF
--- a/view/next-project/src/pages/curriculums/[slug]/Chapters.module.css
+++ b/view/next-project/src/pages/curriculums/[slug]/Chapters.module.css
@@ -5,7 +5,7 @@
 
 .chapters {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(30rem, 1fr));
   justify-items: center;
   gap: 2rem;
 }
@@ -40,6 +40,9 @@
   font-size: 1.75rem;
   font-weight: 600;
   display: block;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .chapterContent {


### PR DESCRIPTION
# WHAT

chapter一覧のスタイルが崩れていることがあったので修正する

# WHY

- chapterのタイトルが長すぎると、grid幅はそれに合わせようとしてしまう
- chapterのカードは`widht: 100%`なので、そのgrid幅ピッタリになってしまう

# HOW

- chapterのタイトルに`text-overflow: ellipsis;`を当てて、はみ出したところを...で埋めるようにした
- gridについて、minmaxをつけてchapterのカードの大きさを制限し、列数をauto-fitで自動調整するようにした

# TEST

- 適当なカリキュラムを作る
- 