### PR TITLE
本番環境で Records のページが見れない問題を解決する

### DIFF
--- a/api/app/controllers/types_controller.rb
+++ b/api/app/controllers/types_controller.rb
@@ -15,7 +15,7 @@ class TypesController < ApplicationController
 
     # POST /types
   def create
-    @type = Skill.new(type_params)
+    @type = Type.new(type_params)
 
     if @type.save
       render json: @type, status: :created, location: @type

--- a/api/app/models/record.rb
+++ b/api/app/models/record.rb
@@ -37,7 +37,7 @@ class Record < ApplicationRecord
           "chapter_title": record.chapter.nil? ? nil: record.chapter.title,
           "curriculum_id": record.chapter.nil? ? nil: record.chapter.curriculum.id,
           "curriculum_title": record.chapter.nil? ? nil: record.chapter.curriculum.title,
-          "skills": record.chapter.curriculum.nil? ? nil: record.chapter.curriculum.skills.map{
+          "skills": record.chapter.nil? || record.chapter.curriculum.nil? ? nil: record.chapter.curriculum.skills.map{
             |skill|
             {
               "name": skill.name,

--- a/api/app/models/record.rb
+++ b/api/app/models/record.rb
@@ -7,12 +7,12 @@ class Record < ApplicationRecord
     record = Record.find(record_id)
     {
       "record": record,
-      "curriculum": record.chapter.curriculum,
-      "curriculum_title": record.chapter.curriculum.title,
-      "chapter": record.chapter,
+      "curriculum": record.chapter.nil? || record.chapter.curriculum.nil? ? nil: record.chapter.curriculum,
+      "curriculum_title": record.chapter.nil? || record.chapter.curriculum.nil? ? nil: record.chapter.curriculum.title,
+      "chapter": record.chapter.nil? ? nil: record.chapter,
       "teacher": record.teacher.user.name,
       "user": record.user.name,
-      "skills": record.chapter.curriculum.skills.map{
+      "skills": record.chapter.nil? || record.chapter.curriculum.nil? ? nil: record.chapter.curriculum.skills.map{
         |skill|
         {
           "id": skill.id,
@@ -60,9 +60,9 @@ class Record < ApplicationRecord
           "user_name": record.user.name,
           "teacher_id": record.teacher.nil? ? nil: record.teacher.user.id,
           "teacher_name": record.teacher.nil? ? nil: record.teacher.user.name,
-          "chapter_id": record.chapter.id,
-          "chapter_title": record.chapter.title,
-          "skills": record.chapter.curriculum.skills.map{
+          "chapter_id": record.chapter.nil? ? nil: record.chapter.id,
+          "chapter_title": record.chapter.nil? ? nil: record.chapter.title,
+          "skills": record.chapter.nil? || record.chapter.curriculum.nil? ? nil: record.chapter.curriculum.skills.map{
             |skill|
             {
               "name": skill.name,

--- a/api/app/models/skill.rb
+++ b/api/app/models/skill.rb
@@ -17,8 +17,8 @@ class Skill < ApplicationRecord
           name: skill.name,
           category_id: skill.category.id,
           category_name: skill.category.name,
-          type_id: skill.type.id,
-          type_name: skill.type.name,
+          type_id: skill.type.nil? ? nil: skill.type.id,
+          type_name: skill.type.nil? ? nil: skill.type.name,
           created_at: skill.created_at,
         }
     }
@@ -32,8 +32,8 @@ class Skill < ApplicationRecord
           name: skill.name,
           category_id: skill.category.id,
           category_name: skill.category.name,
-          type_id: skill.type.id,
-          type_name: skill.type.name,
+          type_id: skill.type.nil? ? nil: skill.type.id,
+          type_name: skill.type.nil? ? nil: skill.type.name,
           created_at: skill.created_at,
         }
     }
@@ -44,6 +44,7 @@ class Skill < ApplicationRecord
       "name": skill.name,
       "detail": skill.detail,
       "category_name": skill.category.name,
+      "type_name": skill.type.nil? ? nil: skill.type.name,
     }
   end
 

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   resources :teachers
   resources :records
   resources :chapters
+  resources :types
   mount_devise_token_auth_for 'User', at: 'auth'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace 'api' do

--- a/api/db/fixtures/record.rb
+++ b/api/db/fixtures/record.rb
@@ -1,5 +1,5 @@
 Record.seed( :id,
-  { id: 1, title: 'TypeScriptで二分木を反転', content: 'test_content', homework: 'test_homework', user_id: 1, chapter_id: 1 },
+  { id: 1, title: 'TypeScriptで二分木を反転', content: 'test_content', homework: 'test_homework', user_id: 1},
   { id: 2, title: 'GoでFizzBuzz', content: 'test_content', homework: 'test_homework', user_id: 2, chapter_id: 2 },
   { id: 3, title: 'Reactのルーティングについての記事を読んだ', content: 'test_content', homework: 'test_homework', user_id: 3, chapter_id: 3 },
   { id: 4, title: 'TypeScriptのインターフェースを書いた', content: 'test_content', homework: 'test_homework', user_id: 4, chapter_id: 4 },

--- a/api/db/fixtures/type.rb
+++ b/api/db/fixtures/type.rb
@@ -3,4 +3,5 @@ Type.seed( :id,
   {id: 2, name: 'frontend'},
   {id: 3, name: 'infra'},
   {id: 4, name: 'design'},
+  {id: 5, name: 'other'},
 )

--- a/view/next-project/src/components/common/RecordDetailHeader/RecordDetailHeader.tsx
+++ b/view/next-project/src/components/common/RecordDetailHeader/RecordDetailHeader.tsx
@@ -12,11 +12,11 @@ interface Props {
   recordTitle: string;
   createDate: string;
   updateDate: string;
-  curriculumTitle: string;
-  chapterTitle: string;
+  curriculumTitle?: string;
+  chapterTitle?: string;
   teacher: string;
   user: string;
-  skill: Skill[];
+  skill?: Skill[];
 }
 
 const RecordDetailHeader = (props: Props) => {
@@ -25,22 +25,23 @@ const RecordDetailHeader = (props: Props) => {
       <div className={s.TitleContainer}>{props.recordTitle}</div>
       <div className={s.TextContainer}>
         <div>
-          <div className={s.DescriptionContainer}>Curriclum:{props.curriculumTitle}</div>
-          <div className={s.DescriptionContainer}>Chapter:{props.chapterTitle}</div>
+          <div className={s.DescriptionContainer}>Curriclum {props.curriculumTitle || 'No Curriculum'}</div>
+          <div className={s.DescriptionContainer}>Chapter {props.chapterTitle || 'No Chapter'}</div>
         </div>
         <div>
-          <div className={s.DescriptionContainer}>Teacher:{props.teacher}</div>
-          <div className={s.DescriptionContainer}>User:{props.user}</div>
+          <div className={s.DescriptionContainer}>Teacher {props.teacher}</div>
+          <div className={s.DescriptionContainer}>User {props.user}</div>
         </div>
       </div>
       <div className={s.TextContainer}>
-        <div className={s.DescriptionContainer}>Create Date:{props.createDate}</div>
-        <div className={s.DescriptionContainer}>Update Date:{props.updateDate}</div>
+        <div className={s.DescriptionContainer}>Create Date {props.createDate}</div>
+        <div className={s.DescriptionContainer}>Update Date {props.updateDate}</div>
       </div>
       <div className={s.SkillContainer}>
-        {props.skill.map((skill) => (
+        {props.skill && props.skill.map((skill) => (
           <Tag key={skill.id}>{skill.name}</Tag>
         ))}
+        {!props.skill && <Tag>No Skill</Tag>}
       </div>
     </div>
   );

--- a/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
+++ b/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
@@ -237,6 +237,7 @@ const RecordEditModal: FC<ModalProps> = (props) => {
           <h3 className={s.contentsTitle}>Curriculum</h3>
           <div className={s.modalContentContents}>
             <select onChange={handleCurriculum}>
+              {formData.chapter_id === null && <option value={formData.chapter_id}>no curriculum</option>}
               {curriculumChapters.map((data: CurriculumChapters) => {
                 return (
                   <option key={data.curriculum.id} value={data.curriculum.id}>
@@ -249,8 +250,9 @@ const RecordEditModal: FC<ModalProps> = (props) => {
           <h3 className={s.contentsTitle}>Chapter</h3>
           <div className={s.modalContentContents}>
             <select onChange={handler('chapter_id')}>
+              {formData.chapter_id === null && <option value={formData.chapter_id}>no chapter</option>}
               {curriculumChapter?.chapters.map((chapter: Chapter) => {
-                if (chapter.id && chapter.id == formData.chapter_id) {
+                if (formData.chapter_id !== null && chapter.id === formData.chapter_id) {
                   return (
                     <option key={chapter.id} value={chapter.id} selected>
                       {chapter.title}

--- a/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
+++ b/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
@@ -175,6 +175,7 @@ const RecordEditModal: FC<ModalProps> = (props) => {
       user_id: data.user_id,
       chapter_id: data.chapter_id,
     };
+    console.log(submitData);
     await put(submitRecordUrl, submitData);
   };
 

--- a/view/next-project/src/components/common/SkillAddModal.tsx
+++ b/view/next-project/src/components/common/SkillAddModal.tsx
@@ -22,6 +22,7 @@ type Skill = {
   name: string;
   detail: string;
   category_id: number;
+  type_id: number;
 }
 
 type Category = {
@@ -29,9 +30,15 @@ type Category = {
   name: string;
 }
 
+type Type = {
+  id: number;
+  name: string;
+}
+
 const SkillAddModal: VFC<ModalProps> = (props) => {
   const [categories, setCategories] = useState<Category[]>([{id: 0, name: ''}])
-  const [skillData, setSkillData] = useState<Skill>({name: '', detail: '', category_id: 0});
+  const [types, setTypes] = useState<Type[]>([{id: 0, name: ''}])
+  const [skillData, setSkillData] = useState<Skill>({name: '', detail: '', category_id: 0, type_id: 0});
   // 選択肢の取得
   useEffect(() => {
     const getCategoriesUrl = process.env.CSR_API_URI + '/categories'
@@ -39,6 +46,12 @@ const SkillAddModal: VFC<ModalProps> = (props) => {
       setCategories(await get(url));
     };
     getCategoires(getCategoriesUrl);
+
+    const getTypesUrl = process.env.CSR_API_URI + '/types'
+    const getTypes = async (url: string) => {
+      setTypes(await get(url));
+    }
+    getTypes(getTypesUrl);
   }, []);
 
   const recordHandler =
@@ -80,6 +93,17 @@ const SkillAddModal: VFC<ModalProps> = (props) => {
         <select onChange={recordHandler('category_id')}>
           <option value=''>Select</option>
           {categories.map((data: Category) => (
+            <option key={data.id} value={data.id}>
+              {data.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <h3>Type</h3>
+        <select onChange={recordHandler('type_id')}>
+          <option value=''>Select</option>
+          {types.map((data: Type) => (
             <option key={data.id} value={data.id}>
               {data.name}
             </option>

--- a/view/next-project/src/components/common/SkillEditModal.tsx
+++ b/view/next-project/src/components/common/SkillEditModal.tsx
@@ -24,15 +24,22 @@ interface Category {
   name: string;
 }
 
+interface Type {
+  id: number;
+  name: string;
+}
+
 const SkillEditModal: FC<ModalProps> = (props) => {
   const router = useRouter();
   const query = router.query;
 
   const [categories, setCategories] = useState<Category[]>([{ id: 0, name: '' }]);
+  const [types, setTypes] = useState<Type[]>([{ id: 0, name: '' }]);
   const [formData, setFormData] = useState({
     name: '',
     detail: '',
     category_id: 0,
+    type_id: 0,
   });
 
   useEffect(() => {
@@ -41,6 +48,12 @@ const SkillEditModal: FC<ModalProps> = (props) => {
       setCategories(await get(url));
     };
     getCategoires(getCategoriesUrl);
+
+    const getTypesUrl = process.env.CSR_API_URI + '/types';
+    const getTypes = async (url: string) => {
+      setTypes(await get(url));
+    };
+    getTypes(getTypesUrl);
 
     if (router.isReady) {
       const getFormDataUrl = process.env.CSR_API_URI + '/skills/' + query.id;
@@ -88,6 +101,26 @@ const SkillEditModal: FC<ModalProps> = (props) => {
         <select defaultValue={formData.category_id} onChange={handler('category_id')}>
           {categories.map((data: Category) => {
             if (data.id == formData.category_id) {
+              return (
+                <option key={data.id} value={data.id} selected>
+                  {data.name}
+                </option>
+              );
+            } else {
+              return (
+                <option key={data.id} value={data.id}>
+                  {data.name}
+                </option>
+              );
+            }
+          })}
+        </select>
+      </div>
+      <div>
+        <h3>Type</h3>
+        <select defaultValue={formData.type_id} onChange={handler('type_id')}>
+          {types.map((data: Type) => {
+            if (data.id == formData.type_id) {
               return (
                 <option key={data.id} value={data.id} selected>
                   {data.name}

--- a/view/next-project/src/constants/tableColumns.tsx
+++ b/view/next-project/src/constants/tableColumns.tsx
@@ -26,7 +26,6 @@ export const SKILL_COLUMNS = [
 export const RECORD_COLUMNS = [
   {
     name: 'Student / Teacher',
-    // "row.user_name / row.teacher_name" にする
     selector: (row: any) => `${row.user_name} / ${row.teacher_name}`,
     sortable: true,
   },
@@ -38,23 +37,21 @@ export const RECORD_COLUMNS = [
   {
     name: 'Skill',
     selector: (row: any) => {
-      const skills = row.skills.sort((a: any, b: any) => {
-        if (a.name < b.name) return -1;
-        if (a.name > b.name) return 1;
-        return 0;
-      });
-      return skills.map((skill: any) => skill.name).join(', ');
+      if (!row.skills) return '';
+      return row.skills
+        .sort((a: any, b: any) => {
+          if (a.name < b.name) return -1;
+          if (a.name > b.name) return 1;
+          return 0;
+        })
+        .map((skill: any) => skill.name)
+        .join(', ');
     },
     sortable: true,
   },
   {
     name: 'Curriculum / Chapter',
-    cell: (row: any) => (
-      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.5rem' }}>
-        <p style={{ fontSize: '1.25rem' }}>{row.curriculum_title}</p>
-        <p style={{ fontSize: '1.25rem' }}>{row.chapter_title}</p>
-      </div>
-    ),
+    cell: (row: any) => (row.curriculum_title ? `${row.curriculum_title} / ${row.chapter_title}` : ''),
     sortable: true,
   },
   {

--- a/view/next-project/src/constants/tableColumns.tsx
+++ b/view/next-project/src/constants/tableColumns.tsx
@@ -13,7 +13,7 @@ export const SKILL_COLUMNS = [
   },
   {
     name: 'Type',
-    selector: (row: any) => row.type_name,
+    selector: (row: any) => row.type_name || '',
     sortable: true,
   },
   {

--- a/view/next-project/src/pages/records/[id]/index.tsx
+++ b/view/next-project/src/pages/records/[id]/index.tsx
@@ -136,9 +136,9 @@ export default function Page(props: Props) {
           recordTitle={props.record.title}
           createDate={formatDate(props.record.created_at)}
           updateDate={formatDate(props.record.updated_at)}
-          curriculumTitle={props.curriculum.title}
-          chapterTitle={props.chapter.title}
-          skill={props.skills}
+          curriculumTitle={props.curriculum?.title}
+          chapterTitle={props.chapter?.title}
+          skill={props?.skills}
           user={props.user}
           teacher={props.teacher}
         />

--- a/view/next-project/src/pages/skills/[id].tsx
+++ b/view/next-project/src/pages/skills/[id].tsx
@@ -1,6 +1,4 @@
 import React, { useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import gfm from 'remark-gfm';
 import { get } from '@utils/api_methods';
 import MainLayout from '@components/layout/MainLayout';
 import FlatCard from '@components/common/FlatCard';
@@ -17,6 +15,7 @@ interface Props {
   name: string;
   detail: string;
   category_name: string;
+  type_name: string;
 }
 
 export async function getServerSideProps({ params }: any) {
@@ -104,11 +103,12 @@ export default function Page(props: Props) {
               Category
               <hr />
             </SkillContentsTitle>
-            <SkillContents>
-              <ReactMarkdown remarkPlugins={[gfm]} unwrapDisallowed={false}>
-                {skillDetail.category_name}
-              </ReactMarkdown>
-            </SkillContents>
+            <SkillContents>{skillDetail.category_name}</SkillContents>
+            <SkillContentsTitle>
+              Type
+              <hr />
+            </SkillContentsTitle>
+            <SkillContents>{skillDetail.type_name}</SkillContents>
           </SkillContentsContainer>
         </FlatCard>
         <ChildButtonContainer>


### PR DESCRIPTION
resolve #183 

# WHAT

- https://github.com/NUTFes/NUTMEG-Seeds/issues/183

# HOW
- records
  - chapter_idがない場合、curriculums / chapterが見れなくなるので、フロント側のテーブルと詳細ページでnull処理を追加した
  - seedデータに、chapter_idがない場合のものを追加した
  - api側でnull処理を追加した
- skills
  - type_idがnullになっていたので、フロント側のテーブルと詳細ページでnull処理を追加した
  - typesのseedデータにその他の項目を追加した
  - routesにtypesを追加して、rubyからtypesを見れるようにした
  - api側でtype_idのnull処理を追加した


# TEST

- [x] recordページが見れるか
  - [x] 詳細ページが見れるか
  - [x] chapterとskillが空のレコードの詳細ページが見れるか
  - [x] chapterとskillが空のレコードの編集ができるか
- [x] skillページが見れるか
  - [x] 個別ページが見れるか
  - [x] 追加できるか
  - [x] 修正できるか