### PR TITLE
レコード・カリキュラムの詳細ページで画面端が選択できない問題を解決する

### DIFF
--- a/view/next-project/src/components/common/BackButton/BackButton.module.css
+++ b/view/next-project/src/components/common/BackButton/BackButton.module.css
@@ -1,4 +1,5 @@
 .ButtonContainer {
+  pointer-events: none;
   z-index: 10;
   top: 0;
   left: 0;
@@ -17,6 +18,7 @@
 }
 
 .ButtonContainer button {
+  pointer-events: auto;
   z-index: 10;
   background: radial-gradient(var(--button-primary), var(--button-secondary));
   width: 60px;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #214 

# 概要
<!-- 開発内容の概要を記載 -->
レコードやカリキュラムの詳細ページで画面端が選択できないので、選択できるようにする。

# 実装内容
<!-- 具体的な開発内容を記載 -->
> 原因究明

BackBottonのCSSが原因でdevがページ上のz軸で一番手前にあったので、カーソルが下の要素にアクセスできなかったと思われる
>原因解決

BackBottonのボタン部分だけアクセスを許可（pointer-events: auto;）して、他の部分はアクセスできないようにした。（pointer-events: none;）

# 変更ファイル
- view/next-project/src/components/common/BackButton/BackButton.module.css

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- http://localhost:8080/records/1
![image](https://github.com/NUTFes/NUTMEG-Seeds/assets/131850959/1a1260c6-f534-4ea4-9e39-3aa87bf3bce6)
- http://localhost:8080/curriculums/1/chapters/1
![image](https://github.com/NUTFes/NUTMEG-Seeds/assets/131850959/f1e47aad-fd04-4fb2-aecf-ab9ee611c2c4)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- BackButtonがある全てのページで、BackButtonのボタン部分の中心よりも左側にあるテキストにアクセス（ドラッグ）できる
- BackButtonがある全てのページで、BackButtonが正常に動く

# 備考
