### PR TITLE
レコード作成時にteacherが木実太郎になるバグを修正する

### DIFF
--- a/view/next-project/src/components/common/RecordAddModal/RecordAddModal.tsx
+++ b/view/next-project/src/components/common/RecordAddModal/RecordAddModal.tsx
@@ -53,8 +53,7 @@ interface CurriculumChapters {
 }
 
 interface Teacher {
-  user_id: number | string;
-  record_id: string;
+  user_id:  string;
 }
 
 interface User {
@@ -72,7 +71,7 @@ const RecordAddModal: FC<ModalProps> = (props) => {
   const [curriculumChapter, setCurriculumChapter] = useState<CurriculumChapters>();
   const [records, setRecords] = useState<Record[]>([]);
   const [users, setUsers] = useState<User[]>([{ id: '', name: '' }]);
-  const [teacherData, setTeacherData] = useState<Teacher>({ user_id: 1, record_id: '' });
+  const [teacherData, setTeacherData] = useState<Teacher>({ user_id: '1' });
   const [isAnimationOpen, setIsAnimationOpen] = useState(false);
   const [newRecordId, setNewRecordId] = useState('');
 
@@ -128,8 +127,8 @@ const RecordAddModal: FC<ModalProps> = (props) => {
     ) => {
       setRecordData({ ...recordData, [input]: e.target.value });
     };
-
-  const handleTeacher = () => (e: React.ChangeEvent<HTMLSelectElement>) => {
+  
+  const handleTeacher = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setTeacherData({ ...teacherData, user_id: e.target.value });
   };
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #217 

# 概要
<!-- 開発内容の概要を記載 -->
レコード作成時に、どのteacherを選んでも木実太郎になるバグの修正

# 実装内容
<!-- 具体的な開発内容を記載 -->
- handleTeacherのアロー関数で空かっこが挟まれている、= () =>を使うときは、引数がない場合に使うものなので、その部分を消去した
- recordを作っているrecords_controller.rbを見に行くと、record_idはRecordAddModalから持ってきているわけではない(record_id: @record.id)ことが分かったので、RecordAddModalのrecord_id部分を消した
- user_idはRecordAddModal以外ではstring型のみのところ(pages/records/index.tsx)があったのでuser_idをstring型のみにした

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
http://localhost:8080/records
PR用テストにおいて、きちんとteacherが反映されている
![image](https://github.com/NUTFes/NUTMEG-Seeds/assets/131850959/66c3968a-7d45-432c-a740-7220329d8fdc)

http://localhost:8080/records/39
PR用テストで、編集したteacherが反映されている
![image](https://github.com/NUTFes/NUTMEG-Seeds/assets/131850959/90a8887a-167b-48cc-9f17-963976c14459)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ レコード作成時のteacherで木実太郎以外を選び、作成されたレコードのteacherが正しく反映されている] 
- [レコードの編集でteacherを変えても、teacherが変更される]
# 備考
本番環境のSeedsでも同じなのだが、teacherがnullのレコードを編集しようとするとエラーが出る