### PR TITLE
編集画面のUI改善

### DIFF
--- a/view/next-project/src/components/common/RecordAddModal/RecordAddModal.tsx
+++ b/view/next-project/src/components/common/RecordAddModal/RecordAddModal.tsx
@@ -90,6 +90,9 @@ const RecordAddModal: FC<ModalProps> = (props) => {
   // 選択状態を管理する新しいstate
   const [selectedCurriculumId, setSelectedCurriculumId] = useState<number | null>(null);
   const [selectedChapterId, setSelectedChapterId] = useState<number | null>(null);
+  
+  // ボタンホバー状態を管理するstate
+  const [isButtonHovered, setIsButtonHovered] = useState(false);
 
   const handleFocus = () => {
     setIsFocused(true);
@@ -208,6 +211,23 @@ const RecordAddModal: FC<ModalProps> = (props) => {
     return !selectedCurriculumId || !selectedChapterId || !teacherData.user_id || teacherData.user_id === '';
   };
 
+  // Save Draftボタンが無効な理由を取得する関数
+  const getDisableReason = () => {
+    const missingItems = [];
+    
+    if (!teacherData.user_id || teacherData.user_id === '') {
+      missingItems.push('Teacherを選択してください');
+    }
+    if (!selectedCurriculumId) {
+      missingItems.push('Curriculumを選択してください');
+    }
+    if (!selectedChapterId) {
+      missingItems.push('Chapterを選択してください');
+    }
+
+    return missingItems.join('、');
+  };
+
   const submitRecord = async (recordData: Record, teacherData: Teacher) => {
     const submitRecordUrl = `${process.env.CSR_API_URI}/records`;
     const submitData = {
@@ -265,16 +285,51 @@ const RecordAddModal: FC<ModalProps> = (props) => {
                   <input type='checkbox' name='check' checked={release} onChange={() => {}} />
                 </div>
               </div>
-              <div className={s.modalSubmitButton}>
-                <Button
-                  onClick={() => {
-                    submitRecord(recordData, teacherData);
-                    setIsAnimationOpen(true);
-                  }}
-                  disabled={isSubmitDisabled()}
+              <div className={s.modalSubmitButton} style={{ position: 'relative' }}>
+                <div
+                  onMouseEnter={() => setIsButtonHovered(true)}
+                  onMouseLeave={() => setIsButtonHovered(false)}
                 >
-                  Save Draft
-                </Button>
+                  <Button
+                    onClick={() => {
+                      submitRecord(recordData, teacherData);
+                      setIsAnimationOpen(true);
+                    }}
+                    disabled={isSubmitDisabled()}
+                  >
+                    Save Draft
+                  </Button>
+                </div>
+                {isSubmitDisabled() && isButtonHovered && (
+                  <div style={{ 
+                    position: 'absolute',
+                    top: '100%',
+                    left: '50%',
+                    transform: 'translateX(-50%)',
+                    backgroundColor: '#333',
+                    color: '#fff',
+                    padding: '6px 8px',
+                    borderRadius: '4px',
+                    fontSize: '12px',
+                    whiteSpace: 'nowrap',
+                    zIndex: 1000,
+                    marginTop: '4px',
+                    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.2)'
+                  }}>
+                    {getDisableReason()}
+                    <div style={{
+                      position: 'absolute',
+                      top: '-5px',
+                      left: '50%',
+                      transform: 'translateX(-50%)',
+                      width: 0,
+                      height: 0,
+                      borderLeft: '5px solid transparent',
+                      borderRight: '5px solid transparent',
+                      borderBottom: '5px solid #333'
+                    }} />
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/view/next-project/src/components/common/RecordAddModal/RecordAddModal.tsx
+++ b/view/next-project/src/components/common/RecordAddModal/RecordAddModal.tsx
@@ -273,6 +273,7 @@ const RecordAddModal: FC<ModalProps> = (props) => {
                 <label className={isFocused ? `${s.label} ${s.focus}` : s.label}>Record Name ( 残りの文字数 : {MAX_TITLE_LENGTH - titleLength} )</label>
               </div>
               <div className={s.mdeWrapper}>
+                <div className={s.selectLabel}>Content</div>
                 <SimpleMde
                   placeholder='Record Write with Markdown'
                   value={recordMarkdown}
@@ -281,6 +282,7 @@ const RecordAddModal: FC<ModalProps> = (props) => {
                 />
               </div>
               <div className={s.mdeWrapper}>
+                <div className={s.selectLabel}>Homework</div>
                 <SimpleMde
                   placeholder='Home Work Write with Markdown'
                   value={homeworkMarkdown}

--- a/view/next-project/src/components/common/RecordAddModal/RecordAddModal.tsx
+++ b/view/next-project/src/components/common/RecordAddModal/RecordAddModal.tsx
@@ -79,11 +79,13 @@ const RecordAddModal: FC<ModalProps> = (props) => {
   const [teacherData, setTeacherData] = useState<Teacher>({ user_id: '1' });
   const [isAnimationOpen, setIsAnimationOpen] = useState(false);
   const [newRecordId, setNewRecordId] = useState('');
-  const [release, setRelease] = useState<boolean>(false);
+  // デフォルトで公開状態に変更（true）
+  const [release, setRelease] = useState<boolean>(true);
   const { isOpen, setIsOpen } = props;
   const [isFocused, setIsFocused] = useState(false);
   const [placeholder, setPlaceholder] = useState('Record Name');
-  const [isActive, setIsActive] = useState(false);
+  // デフォルトで公開状態に変更（true）
+  const [isActive, setIsActive] = useState(true);
 
   const handleFocus = () => {
     setIsFocused(true);
@@ -110,7 +112,8 @@ const RecordAddModal: FC<ModalProps> = (props) => {
     homework: homeworkSentence,
     user_id: Number(localStorage.getItem('user_id')),
     chapter_id: 1,
-  });
+    release: true,
+      });
 
   const [recordMarkdown, setRecordMarkdown] = useState<string>(contentSentence);
   const [homeworkMarkdown, setHomeworkMarkdown] = useState<string>(homeworkSentence);

--- a/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
+++ b/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
@@ -129,6 +129,9 @@ const RecordEditModal: FC<ModalProps> = (props) => {
   const [isDataLoaded, setIsDataLoaded] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
 
+  // ボタンホバー状態を管理するstate
+  const [isButtonHovered, setIsButtonHovered] = useState(false);
+
   // デバッグ用に状態を出力
   useEffect(() => {
     if (isInitialized) {
@@ -379,6 +382,23 @@ const RecordEditModal: FC<ModalProps> = (props) => {
     return !displayCurriculumId || !formData.chapter_id || !displayTeacherId || displayTeacherId === '';
   };
 
+  // Save Draftボタンが無効な理由を取得する関数
+  const getDisableReason = () => {
+    const missingItems = [];
+    
+    if (!displayTeacherId || displayTeacherId === '') {
+      missingItems.push('Teacherを選択してください');
+    }
+    if (!displayCurriculumId) {
+      missingItems.push('Curriculumを選択してください');
+    }
+    if (!formData.chapter_id) {
+      missingItems.push('Chapterを選択してください');
+    }
+
+    return missingItems.join('、');
+  };
+
   // -------------- Submit --------------
   const submitRecord = async () => {
     // 送信データの準備
@@ -530,13 +550,48 @@ const RecordEditModal: FC<ModalProps> = (props) => {
                       <input type='checkbox' name='check' checked={release} onChange={() => {}} />
                     </div>
                   </div>
-                  <div className={s.modalSubmitButton}>
-                    <Button
-                      onClick={handleSubmit}
-                      disabled={isSubmitDisabled()}
+                  <div className={s.modalSubmitButton} style={{ position: 'relative' }}>
+                    <div
+                      onMouseEnter={() => setIsButtonHovered(true)}
+                      onMouseLeave={() => setIsButtonHovered(false)}
                     >
-                      Save Draft
-                    </Button>
+                      <Button
+                        onClick={handleSubmit}
+                        disabled={isSubmitDisabled()}
+                      >
+                        Save Draft
+                      </Button>
+                    </div>
+                    {isSubmitDisabled() && isButtonHovered && (
+                      <div style={{ 
+                        position: 'absolute',
+                        top: '100%',
+                        left: '50%',
+                        transform: 'translateX(-50%)',
+                        backgroundColor: '#333',
+                        color: '#fff',
+                        padding: '6px 8px',
+                        borderRadius: '4px',
+                        fontSize: '12px',
+                        whiteSpace: 'nowrap',
+                        zIndex: 1000,
+                        marginTop: '4px',
+                        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.2)'
+                      }}>
+                        {getDisableReason()}
+                        <div style={{
+                          position: 'absolute',
+                          top: '-5px',
+                          left: '50%',
+                          transform: 'translateX(-50%)',
+                          width: 0,
+                          height: 0,
+                          borderLeft: '5px solid transparent',
+                          borderRight: '5px solid transparent',
+                          borderBottom: '5px solid #333'
+                        }} />
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
+++ b/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
@@ -304,6 +304,7 @@ const RecordEditModal: FC<ModalProps> = (props) => {
 
                   {/* Record内容(Markdown) */}
                   <div className={s.mdeWrapper}>
+                    <div className={s.selectLabel}>Content</div>
                     <SimpleMde
                       placeholder='Record Write with Markdown'
                       value={recordMarkdown}
@@ -314,6 +315,7 @@ const RecordEditModal: FC<ModalProps> = (props) => {
 
                   {/* Homework(Markdown) */}
                   <div className={s.mdeWrapper}>
+                    <div className={s.selectLabel}>Homework</div>
                     <SimpleMde
                       placeholder='Home Work Write with Markdown'
                       value={homeworkMarkdown}

--- a/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
+++ b/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
@@ -374,6 +374,11 @@ const RecordEditModal: FC<ModalProps> = (props) => {
     }
   };
 
+  // ボタンの有効/無効を判定する関数
+  const isSubmitDisabled = () => {
+    return !displayCurriculumId || !formData.chapter_id || !displayTeacherId || displayTeacherId === '';
+  };
+
   // -------------- Submit --------------
   const submitRecord = async () => {
     // 送信データの準備
@@ -528,6 +533,7 @@ const RecordEditModal: FC<ModalProps> = (props) => {
                   <div className={s.modalSubmitButton}>
                     <Button
                       onClick={handleSubmit}
+                      disabled={isSubmitDisabled()}
                     >
                       Save Draft
                     </Button>

--- a/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
+++ b/view/next-project/src/components/common/RecordEditModal/RecordEditModal.tsx
@@ -13,6 +13,7 @@ const SimpleMde = dynamic(() => import('react-simplemde-editor'), { ssr: false }
 interface ModalProps {
   isOpen: boolean;
   setIsOpen: Function;
+  recordId?: string | string[]; // recordIdをPropsとして受け取る
 }
 
 interface Curriculum {
@@ -61,6 +62,7 @@ interface RecordData {
   created_at?: string;
   updated_at?: string;
   release?: boolean;
+  curriculum_id?: number; // 追加: データ取得時に明示的にcurriculum_idも持つようにする
 }
 
 interface RecordCurriculumTeacher {
@@ -75,10 +77,12 @@ interface RecordCurriculumTeacher {
 const RecordEditModal: FC<ModalProps> = (props) => {
   const router = useRouter();
   const { id } = router.query;
+  const recordId = props.recordId || id; // recordIdをpropsから取得、なければrouterから取得
 
   // -------------- State --------------
   const [curriculumChapters, setCurriculumChapters] = useState<CurriculumChapters[]>([]);
   const [curriculumChapter, setCurriculumChapter] = useState<CurriculumChapters>();
+  const [selectedCurriculumId, setSelectedCurriculumId] = useState<number | null>(null);
   const [users, setUsers] = useState<User[]>([{ id: '', name: '' }]);
   const [teacherData, setTeacherData] = useState<Teacher>({ id: '', user_id: '', record_id: '' });
   const [record, setRecord] = useState<RecordCurriculumTeacher>({
@@ -98,7 +102,12 @@ const RecordEditModal: FC<ModalProps> = (props) => {
     user_id: 0,
     chapter_id: 0,
     release: false,
+    curriculum_id: 0,
   });
+
+  // 表示用State
+  const [displayCurriculumId, setDisplayCurriculumId] = useState<string | number>('');
+  const [displayTeacherId, setDisplayTeacherId] = useState<string>('');
 
   // Markdown用
   const [recordMarkdown, setRecordMarkdown] = useState<string>('');
@@ -116,43 +125,162 @@ const RecordEditModal: FC<ModalProps> = (props) => {
   const [isFocused, setIsFocused] = useState(false);
   const [placeholder, setPlaceholder] = useState('Record Name');
 
-  // -------------- useEffect --------------
+  // データが読み込まれたかどうか
+  const [isDataLoaded, setIsDataLoaded] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // デバッグ用に状態を出力
   useEffect(() => {
-    // カリキュラム一覧取得
-    const getCurriculumChaptersUrl = process.env.CSR_API_URI + '/api/v1/get_curriculums_chapter_for_index';
-    get(getCurriculumChaptersUrl).then((data) => {
-      setCurriculumChapters(data);
-      setCurriculumChapter(data[0]); // 初期値で一旦先頭をセット
-    });
-
-    // ユーザ一覧取得
-    const getUsersUrl = process.env.CSR_API_URI + '/api/v1/users';
-    get(getUsersUrl).then((res) => setUsers(res));
-
-    // レコード詳細の取得
-    if (router.isReady && id) {
-      const getFormDataUrl = `${process.env.CSR_API_URI}/records/${id}`;
-      get(getFormDataUrl).then((res) => {
-        setFormData(res);
-        setRecordMarkdown(res.content);
-        setHomeworkMarkdown(res.homework);
-        setRelease(res.release);
-        setTitleLength(res.title.length);
-      });
-
-      // Teacher情報の取得
-      const getTeacherDataUrl = `${process.env.CSR_API_URI}/api/v1/get_teacher_by_record/${id}`;
-      get(getTeacherDataUrl).then((res) => {
-        setTeacherData(res);
-      });
-
-      // Record + Curriculum + Teacherまとめて取るAPI
-      const getRecordUrl = `${process.env.CSR_API_URI}/api/v1/record/${id}`;
-      get(getRecordUrl).then((res) => {
-        setRecord(res);
-      });
+    if (isInitialized) {
+      console.log("[Debug] Current State:");
+      console.log("[Debug] - Curriculum ID (internal):", selectedCurriculumId);
+      console.log("[Debug] - Curriculum ID (display):", displayCurriculumId);
+      console.log("[Debug] - Teacher ID:", displayTeacherId);
+      console.log("[Debug] - Chapter ID:", formData.chapter_id);
+      console.log("[Debug] - Current chapter data:", curriculumChapter?.chapters?.find(c => c.id === formData.chapter_id));
     }
-  }, [id, router.isReady]);
+  }, [selectedCurriculumId, displayCurriculumId, displayTeacherId, formData.chapter_id, curriculumChapter, isInitialized]);
+
+  // -------------- useEffect --------------
+  // 初回および表示時のデータ取得・設定
+  useEffect(() => {
+    if (!props.isOpen) return; // モーダルが閉じている場合は何もしない
+    
+    console.log("[Initialize] Modal is now open, starting initialization");
+    setIsDataLoaded(false);
+    setIsInitialized(false);
+    
+    // データ初期化処理
+    const initializeModal = async () => {
+      try {
+        console.log("[Initialize] Fetching data for record ID:", recordId);
+        
+        // レコード情報と関連データの取得
+        let recordData, teacherData, recordWithRelations;
+        let curriculumsData: CurriculumChapters[] = [];
+        let usersData: User[] = [];
+
+        // データ取得のためのURL
+        const getCurriculumChaptersUrl = process.env.CSR_API_URI + '/api/v1/get_curriculums_chapter_for_index';
+        const getUsersUrl = process.env.CSR_API_URI + '/api/v1/users';
+        
+        // ユーザ一覧とカリキュラム情報の取得
+        [curriculumsData, usersData] = await Promise.all([
+          get(getCurriculumChaptersUrl),
+          get(getUsersUrl)
+        ]);
+        
+        console.log("[Initialize] Loaded curriculum chapters:", curriculumsData.length);
+        console.log("[Initialize] Loaded users:", usersData.length);
+        
+        // Stateを更新
+        setCurriculumChapters(curriculumsData);
+        setUsers(usersData);
+        
+        // 編集モード（既存レコードの取得）
+        if (recordId) {
+          console.log("[Initialize] Fetching existing record data for ID:", recordId);
+          
+          const recordUrl = `${process.env.CSR_API_URI}/records/${recordId}`;
+          const teacherUrl = `${process.env.CSR_API_URI}/api/v1/get_teacher_by_record/${recordId}`;
+          // エラーが出ているAPIエンドポイントを修正
+          const recordWithRelationsUrl = `${process.env.CSR_API_URI}/api/v1/get_record_for_view/${recordId}`;
+          
+          try {
+            [recordData, teacherData, recordWithRelations] = await Promise.all([
+              get(recordUrl),
+              get(teacherUrl),
+              get(recordWithRelationsUrl)
+            ]);
+            
+            // 結果のログ出力
+            console.log("[Initialize] Record data:", recordData);
+            console.log("[Initialize] Teacher data:", teacherData);
+            console.log("[Initialize] Record with relations:", recordWithRelations);
+            
+            // Record関連データをセット
+            setRecord(recordWithRelations);
+            
+            // Teacher情報をセット - 動作確認済み
+            if (teacherData && teacherData.user_id) {
+              console.log("[Initialize] Setting teacher ID:", teacherData.user_id);
+              setTeacherData(teacherData);
+              setDisplayTeacherId(teacherData.user_id);
+            }
+            
+            // カリキュラムデータの処理 - ここが改善ポイント
+            let curriculumId: number | undefined = undefined;
+            
+            // レコードの基本情報をセット
+            if (recordData) {
+              console.log("[Initialize] Setting form data. Chapter ID:", recordData.chapter_id);
+              setFormData(recordData);
+              setRecordMarkdown(recordData.content || '');
+              setHomeworkMarkdown(recordData.homework || '');
+              setTitleLength(recordData.title ? recordData.title.length : 0);
+              
+              // 公開状態の設定
+              const isReleased = recordData.release === true;
+              setRelease(isReleased);
+              setIsActive(isReleased);
+            }
+            
+            // recordWithRelationsからカリキュラム情報を取得
+            if (recordWithRelations && recordWithRelations.curriculum && recordWithRelations.curriculum.id) {
+              curriculumId = Number(recordWithRelations.curriculum.id);
+              console.log("[Initialize] Found curriculum from relations. ID:", curriculumId);
+              
+              // Teacherと同様に直接表示値を設定
+              setSelectedCurriculumId(curriculumId);
+              setDisplayCurriculumId(curriculumId);
+              
+              // 対応するカリキュラムをcurriculumChaptersから検索
+              const matchingCurriculum = curriculumsData.find(
+                c => c.curriculum.id === curriculumId
+              );
+              
+              if (matchingCurriculum) {
+                console.log("[Initialize] Found matching curriculum:", matchingCurriculum.curriculum.title);
+                console.log("[Initialize] Has chapters:", matchingCurriculum.chapters?.length || 0);
+                setCurriculumChapter(matchingCurriculum);
+                
+                // formDataの更新では直接curriculumIdを使用 (nullの場合はundefinedに)
+                if (curriculumId !== undefined) {
+                  setFormData(prev => ({
+                    ...prev,
+                    curriculum_id: curriculumId
+                  }));
+                }
+              } else {
+                console.warn("[Initialize] Curriculum not found in available curricula");
+              }
+            } else {
+              console.log("[Initialize] No curriculum data in record relation");
+            }
+          } catch (error) {
+            console.error("[Initialize] Error fetching record data:", error);
+          }
+          
+        } else {
+          // 新規作成モードの場合
+          console.log("[Initialize] New record mode");
+        }
+        
+        // 初期化完了
+        setIsDataLoaded(true);
+        setIsInitialized(true);
+        console.log("[Initialize] Initialization completed");
+        
+      } catch (error) {
+        console.error("[Initialize] データ取得エラー:", error);
+        setIsDataLoaded(true);
+        setIsInitialized(true);
+      }
+    };
+    
+    initializeModal();
+    
+  }, [props.isOpen, recordId]);
 
   // -------------- Handler --------------
 
@@ -174,20 +302,53 @@ const RecordEditModal: FC<ModalProps> = (props) => {
         }
       } else {
         setFormData({ ...formData, [input]: value });
+        
+        // chapter_idの場合、数値に変換
+        if (input === 'chapter_id') {
+          const numValue = value ? Number(value) : 0;
+          console.log("[Handler] Chapter ID changed to:", numValue);
+        }
       }
     };
 
   // Teacher選択
   const teacherHandler = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    // teacherDataにも記録
-    setTeacherData({ ...teacherData, user_id: e.target.value, record_id: String(id) });
+    const value = e.target.value;
+    console.log("[Handler] Teacher selected:", value);
+    setDisplayTeacherId(value);
+    setTeacherData({ ...teacherData, user_id: value, record_id: String(recordId) });
   };
 
   // Curriculum選択
   const handleCurriculum = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const selected = curriculumChapters.find((c) => c.curriculum.id === Number(e.target.value));
+    const value = e.target.value;
+    if (!value) {
+      console.log("[Handler] No curriculum selected");
+      setSelectedCurriculumId(null);
+      setDisplayCurriculumId('');
+      setCurriculumChapter(undefined);
+      setFormData(prev => ({...prev, chapter_id: 0, curriculum_id: undefined}));
+      return;
+    }
+    
+    const selectedId = Number(value);
+    console.log("[Handler] Curriculum selected:", selectedId);
+    
+    const selected = curriculumChapters.find((c: CurriculumChapters) => c.curriculum.id === selectedId);
     if (selected) {
+      console.log("[Handler] Found curriculum:", selected.curriculum.title);
+      console.log("[Handler] Has chapters:", selected.chapters?.length || 0);
+      
+      setSelectedCurriculumId(selectedId);
+      setDisplayCurriculumId(selectedId);
       setCurriculumChapter(selected);
+      
+      // カリキュラム変更時はchapter_idをリセットし、curriculum_idを設定
+      setFormData(prev => ({
+        ...prev, 
+        chapter_id: 0,
+        curriculum_id: selectedId
+      }));
     }
   };
 
@@ -215,37 +376,132 @@ const RecordEditModal: FC<ModalProps> = (props) => {
 
   // -------------- Submit --------------
   const submitRecord = async () => {
-    // レコードの更新
-    const submitRecordUrl = `${process.env.CSR_API_URI}/records/${id}`;
-    const submitData = {
-      record: {
-        title: formData.title,
-        content: recordMarkdown,
-        homework: homeworkMarkdown,
-        user_id: formData.user_id,
-        chapter_id: formData.chapter_id,
-        release: release,
-      },
+    // 送信データの準備
+    const recordSubmitData: any = {
+      title: formData.title,
+      content: recordMarkdown,
+      homework: homeworkMarkdown,
+      user_id: formData.user_id,
+      release: release,
     };
-    await put(submitRecordUrl, submitData);
+    
+    // チャプターIDが選択されている場合は含める
+    // 0やundefinedの場合もAPI側でNULLとして処理されるので明示的に含める
+    recordSubmitData.chapter_id = formData.chapter_id || 0;
+    console.log("[Submit] Including chapter_id:", recordSubmitData.chapter_id);
+    
+    // 選択されているカリキュラムIDがある場合は明示的に含める
+    // これにより、バックエンドでカリキュラムとチャプターの関連付けが正しく行われる
+    if (selectedCurriculumId) {
+      recordSubmitData.curriculum_id = selectedCurriculumId;
+      console.log("[Submit] Including curriculum_id:", selectedCurriculumId);
+    }
+    
+    // レコードの更新
+    const submitRecordUrl = `${process.env.CSR_API_URI}/records/${recordId}`;
+    const submitData = {
+      record: recordSubmitData
+    };
+    
+    console.log("[Submit] Sending record data:", JSON.stringify(submitData));
+    
+    try {
+      const response = await put(submitRecordUrl, submitData);
+      console.log('[Submit] Record updated:', response);
+      return true;
+    } catch (error) {
+      console.error('[Submit] Error updating record:', error);
+      return false;
+    }
   };
 
   const submitTeacher = async () => {
     // Teacherの更新
-    // 既に teacher.id があればPUT、なければPOSTの可能性もありますが、
-    // ここではPUT前提に。
-    const submitTeacherUrl = `${process.env.CSR_API_URI}/teachers/${teacherData.id}`;
-    const submitData: Teacher = {
-      user_id: teacherData.user_id,
-      record_id: teacherData.record_id,
-    };
-    await put(submitTeacherUrl, submitData);
-    router.reload();
+    if (!teacherData.user_id) {
+      console.error('[Submit] Teacher user_id is required');
+      return false;
+    }
+    
+    try {
+      const submitTeacherUrl = `${process.env.CSR_API_URI}/teachers/${teacherData.id}`;
+      const submitData: Teacher = {
+        user_id: teacherData.user_id,
+        record_id: String(recordId),
+      };
+      console.log("[Submit] Sending teacher data:", JSON.stringify(submitData));
+      
+      const response = await put(submitTeacherUrl, submitData);
+      console.log('[Submit] Teacher updated:', response);
+      return true;
+    } catch (error) {
+      console.error('[Submit] Error updating teacher:', error);
+      return false;
+    }
+  };
+
+  // 変更を保存して編集画面を閉じる
+  const handleSubmit = async () => {
+    console.log('[Submit] Submit button clicked');
+    console.log('[Submit] Current form state:', {
+      title: formData.title,
+      content: (recordMarkdown || '').substring(0, 50) + '...', // 長すぎるので省略
+      homework: (homeworkMarkdown || '').substring(0, 50) + '...', // 長すぎるので省略
+      user_id: formData.user_id,
+      chapter_id: formData.chapter_id,
+      curriculum_id: selectedCurriculumId || formData.curriculum_id,
+      release: release,
+      teacher_user_id: teacherData.user_id,
+      displayCurriculum: displayCurriculumId,
+      displayTeacher: displayTeacherId
+    });
+    
+    const recordSuccess = await submitRecord();
+    const teacherSuccess = await submitTeacher();
+    
+    if (recordSuccess && teacherSuccess) {
+      console.log('[Submit] All updated successfully, closing modal and reloading page');
+      // 成功したらモーダルを閉じる
+      props.setIsOpen(false);
+      // ページをリロード
+      router.reload();
+    } else {
+      console.error('[Submit] Update failed');
+      alert('更新に失敗しました。再度お試しください。');
+    }
   };
 
   // 閉じる
   const handleClose = () => {
     props.setIsOpen(false);
+  };
+
+  // Chapterドロップダウンのオプション表示
+  const renderChapterOptions = () => {
+    if (!curriculumChapter || !curriculumChapter.chapters || curriculumChapter.chapters.length === 0) {
+      return null;
+    }
+    
+    return curriculumChapter.chapters.map((chapter: Chapter) => (
+      <option key={chapter.id} value={chapter.id}>
+        {chapter.title}
+      </option>
+    ));
+  };
+  
+  // カリキュラムが選択されているか
+  const hasCurriculum = displayCurriculumId !== '' && displayCurriculumId !== 0;
+  
+  // チャプタードロップダウンのプレースホルダーテキスト
+  const getChapterPlaceholderText = () => {
+    if (!hasCurriculum) {
+      return 'カリキュラムを選択してください';
+    }
+    
+    if (!curriculumChapter || !curriculumChapter.chapters || curriculumChapter.chapters.length === 0) {
+      return 'チャプターがありません';
+    }
+    
+    return 'チャプターを選択してください';
   };
 
   return (
@@ -271,10 +527,7 @@ const RecordEditModal: FC<ModalProps> = (props) => {
                   </div>
                   <div className={s.modalSubmitButton}>
                     <Button
-                      onClick={() => {
-                        submitRecord();
-                        submitTeacher();
-                      }}
+                      onClick={handleSubmit}
                     >
                       Save Draft
                     </Button>
@@ -332,13 +585,10 @@ const RecordEditModal: FC<ModalProps> = (props) => {
                     <div className={s.selectWrapper}>
                       <div className={s.selectLabel}>Teacher</div>
                       <select
-                        // teacherData.user_id を反映
-                        value={teacherData.user_id || ''}
+                        value={displayTeacherId}
                         onChange={teacherHandler}
                       >
-                        <option value='' hidden>
-                          Tap and Choose
-                        </option>
+                        <option value=''>Tap and Choose</option>
                         {users.map((user) => (
                           <option key={user.id} value={user.id}>
                             {user.name}
@@ -353,14 +603,11 @@ const RecordEditModal: FC<ModalProps> = (props) => {
                     <div className={s.selectWrapper}>
                       <div className={s.selectLabel}>Curriculum</div>
                       <select
-                        // 選択中のカリキュラムIDを反映
-                        value={curriculumChapter?.curriculum.id ?? ''}
+                        value={displayCurriculumId}
                         onChange={handleCurriculum}
                       >
-                        <option value='' hidden>
-                          Tap and Choose
-                        </option>
-                        {curriculumChapters.map((c) => (
+                        <option value=''>Tap and Choose</option>
+                        {curriculumChapters.map((c: CurriculumChapters) => (
                           <option key={c.curriculum.id} value={c.curriculum.id}>
                             {c.curriculum.title}
                           </option>
@@ -374,18 +621,13 @@ const RecordEditModal: FC<ModalProps> = (props) => {
                     <div className={s.selectWrapper}>
                       <div className={s.selectLabel}>Chapter</div>
                       <select
-                        // formData.chapter_id を反映
                         value={formData.chapter_id || ''}
                         onChange={handler('chapter_id')}
                       >
-                        <option value='' hidden>
-                          Tap and Choose
+                        <option value=''>
+                          {getChapterPlaceholderText()}
                         </option>
-                        {curriculumChapter?.chapters.map((chapter) => (
-                          <option key={chapter.id} value={chapter.id}>
-                            {chapter.title}
-                          </option>
-                        ))}
+                        {renderChapterOptions()}
                       </select>
                     </div>
                   </div>

--- a/view/next-project/src/components/common/TestButton.tsx
+++ b/view/next-project/src/components/common/TestButton.tsx
@@ -8,12 +8,15 @@ type ButtonContentsProps = {
   text?: string;
   onClick?: (event: any) => void;
   type?: 'button' | 'submit';
+  disabled?: boolean;
   children: React.ReactNode;
 };
 
 function TestButton(props: ButtonContentsProps): JSX.Element {
   const ButtonContainer = styled.button`
-    background: radial-gradient(ellipse at top left, var(--button-primary), var(--button-secondary));
+    background: ${props.disabled 
+      ? 'linear-gradient(ellipse at top left, #ccc, #999)' 
+      : 'radial-gradient(ellipse at top left, var(--button-primary), var(--button-secondary))'};
     width: ${props.width || '150px'};
     height: ${props.height || '40px'};
     border-radius: var(--button-radius);
@@ -21,21 +24,27 @@ function TestButton(props: ButtonContentsProps): JSX.Element {
     backdrop-filter: blur(4px);
     text-align: center;
     font-size: 14px;
-    color: var(--accent-0);
+    color: ${props.disabled ? '#666' : 'var(--accent-0)'};
     display: flex;
     justify-content: center;
     align-items: center;
     border: none;
+    cursor: ${props.disabled ? 'not-allowed' : 'pointer'};
+    opacity: ${props.disabled ? 0.6 : 1};
     &:active {
-      box-shadow: 0 0px 0px rgba(0, 0, 0, 0.25);
+      box-shadow: ${props.disabled ? '0 2px 2px rgba(0, 0, 0, 0.25)' : '0 0px 0px rgba(0, 0, 0, 0.25)'};
     }
   `;
 
   return (
-    <ButtonContainer onClick={props.onClick} type={props.type}>
+    <ButtonContainer 
+      onClick={props.disabled ? undefined : props.onClick} 
+      type={props.type}
+      disabled={props.disabled}
+    >
       {props.children}
       {props.text}
-      <RightArrow height={16} width={16} color='var(--accent-0)' />
+      <RightArrow height={16} width={16} color={props.disabled ? '#666' : 'var(--accent-0)'} />
     </ButtonContainer>
   );
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #260 

# 概要
<!-- 開発内容の概要を記載 -->
編集画面のUI改善を行いました。
- 初回表示の選択値が反映されない問題の修正
- 入力画面をわかりやすく修正

# 実装内容
<!-- 具体的な開発内容を記載 -->
## 1. 初回表示の選択値が反映されない問題の修正

### Teacherの選択表示の問題

- Teacherは正しく表示されていましたが、カリキュラムとチャプターの選択値が表示されていませんでした
- 選択値を表示するための適切な状態管理を追加しました
- Teacher表示のロジックを参考に、カリキュラムとチャプターにも同様のアプローチを適用しました

### 別々の表示状態による分離

- 内部データ（selectedCurriculumId）と表示用データ（displayCurriculumId）を分離
- 表示用の状態をAPIレスポンスから直接設定するよう修正

## 2. APIエンドポイントの修正

### エラーログの分析と修正

- サーバーログから「The action 'get_record' could not be found」エラーを特定
- `/api/v1/record/${recordId}` から `/api/v1/get_record_for_view/${recordId}` に変更
- エラーログが提案していた正しいエンドポイントに修正

## 3. 作成ページ、編集ページの入力箇所をわかりやすく明記


# 画面スクリーンショット等
<!-- URLととも
![スクリーンショット 2025-05-20 17 54 44](https://github.com/user-attachments/assets/269a8a75-734d-4dfa-bf04-34a2ab7a09e1)
に貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] 編集画面を開いた際に現在の内容からの編集となっている。
- [ ] Post作成時にデフォルトでRelease表示になっている。


# 備考
- 初期化処理と状態管理の整理
- デバッグログの追加による状態追跡の容易化
- データ初期化から表示、保存までの一貫した流れの実現